### PR TITLE
metadataUrls can be a string if coming from the layer config

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -399,7 +399,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
      * Adds the action for the metadata
      */
     addMetadata: function(item, nodeConfig) {
-        var metadataUrl = null;
+        var metadataUrl;
         if (Ext.isString(item.metadataUrls)) {
             metadataUrl = item.metadataUrls;
         }


### PR DESCRIPTION
this pull request fixes the case of bad metadata urls when metadataUrls were coming from the layer config.
