### PR TITLE
fix permalink with empty groups

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -720,7 +720,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         if (!this.initialState) {
             return;
         }
-        if (this.initialState.groups) {
+        if (this.initialState.groups !== undefined) {
             this.defaultThemes = null;
         }
         var groups = Ext.isArray(this.initialState.groups) ?


### PR DESCRIPTION
Actuellement quand on supprime tous les overlay et que l'on crée un permalink il nous ouvre le theme par défaut ...

CU
Stéphane
