### PR TITLE
IE7 compatibility fixes

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -230,8 +230,13 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
                     trackMouse: true,
                     dismissDelay: 15000
                 });
-                function stop(event) {
-                    event.stopPropagation();
+                function stop(e) {
+                    var event = e || window.event;
+                    if (event.stopPropagation) {
+                        event.stopPropagation();
+                    } else {
+                        event.cancelBubble = true;
+                    }
                 }
                 component.getEl().dom.onkeydown = stop;
             },

--- a/core/src/script/CGXP/plugins/Measure.js
+++ b/core/src/script/CGXP/plugins/Measure.js
@@ -160,6 +160,10 @@ cgxp.plugins.Measure = Ext.extend(gxp.plugins.Tool, {
                     closeAction: 'hide',
                     location: new OpenLayers.LonLat(0, 0)
                 });
+                if (Ext.isIE7) {
+                    // IE7 needs an explicit width.
+                    this.popup.setWidth(200);
+                }
             }
             this.popup.hide();
             var singlePoint = false;

--- a/core/src/script/CGXP/plugins/ThemeFinder.js
+++ b/core/src/script/CGXP/plugins/ThemeFinder.js
@@ -177,8 +177,13 @@ cgxp.plugins.ThemeFinder = Ext.extend(gxp.plugins.Tool, {
                 }
             },
             'render': function(component) {
-                function stop(event) {
-                    event.stopPropagation();
+                function stop(e) {
+                    var event = e || window.event;
+                    if (event.stopPropagation) {
+                        event.stopPropagation();
+                    } else {
+                        event.cancelBubble = true;
+                    }
                 }
                 component.getEl().dom.onkeydown = stop;
             },

--- a/core/src/script/CGXP/plugins/ThemeSelector.js
+++ b/core/src/script/CGXP/plugins/ThemeSelector.js
@@ -108,11 +108,12 @@ cgxp.plugins.ThemeSelector = Ext.extend(gxp.plugins.Tool, {
         }
         var tabs = new Ext.TabPanel({
             width: 530,
-            activeItem: 0,
+            activeTab: 0,
             plain: true,
             border: false,
             tabPosition: 'bottom',
             items: items,
+            deferredRender: false,
             listeners: {
                 tabchange: function(cmp) {
                     cmp.ownerCt.doLayout();


### PR DESCRIPTION
This pull request deals with various bugs occuring with IE7:
1. `Measure` plugin: the popup displaying the Measure tools results has no explicit width config. No big deal with FF, Chrome or IE8+ but in IE7 the window is shown with a very wide width. Suggested solution: providing an explicit width (200px) when IE7 is detected.
2. `FullTextSearch` and `ThemeFinder` plugins: event propagation stop for combo tools (fulltextsearch and themeFinder). In IE7/8/9, no event parameter is passed to the `onkeydown` handler. On the other hand, the event object is available using `window.event`. In addition, `stopPropagation()` is not available whereas IE supports the `cancelBubbles` attribute.
3. `ThemeSelector` plugin: in IE7 (OK for newer versions), the theme selector TabPanel height is incorrect (themes icons are not visible), whereas there are 1 or 2 tabs displayed. Using `activeTab` instead of `activeItem` and making sure that the content rendering is not deferred (`deferredRender: false`) solves the pb.
