### PR TITLE
add possibility to set a text config/i18n to the Help action

### DIFF
--- a/core/src/script/CGXP/plugins/Help.js
+++ b/core/src/script/CGXP/plugins/Help.js
@@ -45,6 +45,7 @@ cgxp.plugins.Help = Ext.extend(gxp.plugins.Tool, {
     url: null,
 
     helpactiontooltipText: "Help",
+    helpactionText: null,
 
     /** api: config[options]
      *  ``Object``
@@ -58,6 +59,7 @@ cgxp.plugins.Help = Ext.extend(gxp.plugins.Tool, {
         var action = new GeoExt.Action(Ext.apply({
             iconCls: "help",
             tooltip: this.helpactiontooltipText,
+            text: this.helpactionText,
             handler: function() {
                 window.open(this.url);
             },


### PR DESCRIPTION
By default the Help button has no text.
With this change, one can set a text in addition to the icon either by adding a "helpactionText" parameter to the plugin config or by adding GeoExt translations.
