### PR TITLE
add support of layerGroup's isExpanded parameter

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -317,6 +317,9 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         this.fireEvent('addgroup');
         groupNode.expand(true, false);
         groupNode.collapse(true, false);
+        if (group.isExpanded) {
+            groupNode.expand(false, false); 
+        }
         groupNode.cascade(this.checkInRange);
     },
 


### PR DESCRIPTION
Default layertree behaviour is to expand then collapse the treenodes. For layergroup of first level (directly linked to a theme), this change reopens them.
Note that it doesn't work for layergroups themselves embedded in a parent layergroup (TODO).
