### PR TITLE
Google Earth button options

### DIFF
--- a/core/src/script/CGXP/plugins/GoogleEarthView.js
+++ b/core/src/script/CGXP/plugins/GoogleEarthView.js
@@ -83,10 +83,10 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
      */
     addActions: function() {
         this.outputTarget = Ext.getCmp(this.outputTarget);
-        var button = new Ext.Button(Ext.apply({}, this.buttonConfig, {
+        var button = new Ext.Button(Ext.apply({
             enableToggle: true,
             iconCls: "cgxp-icon-googleearthview"
-        }));
+        }, this.buttonConfig));
         button.on({
             "toggle": function(button) {
                 if (button.pressed) {


### PR DESCRIPTION
This pull request fixes issue #60.

Note that `toggleGroup` should now be set in `buttonOptions`, rather than in the config of the plugin.
