### PR TITLE
Computation of resolution hint was incorrect

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -580,15 +580,16 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             case 'zoomtoscale':
                     var n = node,
                     map = n.layer.map,
-                    res = map.getResolution(),
+                    pixelDiagonal = Math.sqrt(2),
+                    resolutionHint = pixelDiagonal * map.getResolution(),
                     zoom,
                     center = map.getCenter(),
                     minResolutionHint = n.attributes.minResolutionHint,
                     maxResolutionHint = n.attributes.maxResolutionHint;
-                if (maxResolutionHint && maxResolutionHint < res) {
-                    zoom = map.getZoomForResolution(maxResolutionHint) + 1;
-                } else if (minResolutionHint && minResolutionHint > res) {
-                    zoom = map.getZoomForResolution(minResolutionHint);
+                if (maxResolutionHint && maxResolutionHint < resolutionHint) {
+                    zoom = map.getZoomForResolution(maxResolutionHint / pixelDiagonal) + 1;
+                } else if (minResolutionHint && minResolutionHint > resolutionHint) {
+                    zoom = map.getZoomForResolution(minResolutionHint / pixelDiagonal);
                 }
                 map.setCenter(center, zoom);
                 break;
@@ -875,7 +876,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         }
         var n = node,
             map = n.layer.map,
-            resolution = map.getResolution(),
+            pixelDiagonal = Math.sqrt(2),
+            resolutionHint = pixelDiagonal * map.getResolution(),
             minResolutionHint = n.attributes.minResolutionHint,
             maxResolutionHint = n.attributes.maxResolutionHint;
         if (n.getUI().rendered) {
@@ -884,7 +886,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             var zoomToScale = Ext.select(".gx-tree-layer-actions img.zoomtoscale", true, n.getUI().elNode);
             zoomToScale.setVisibilityMode(Ext.Element.DISPLAY);
 
-            if ((minResolutionHint && minResolutionHint > resolution) || (maxResolutionHint && maxResolutionHint < resolution)) {
+            if ((minResolutionHint && minResolutionHint > resolutionHint) ||
+                (maxResolutionHint && maxResolutionHint < resolutionHint)) {
                 n.getUI().addClass("gx-tree-layer-outofrange");
                 legend.hide();
                 zoomToScale.show();


### PR DESCRIPTION
We use resolutionHint (generally best known as scaleHint) to check if a layer is visible at current resolution and to zoom to the "next visible scale".

To do so we used to compare minResolutionHint and maxResolutionHint (available as min/max values of layer's ScaleHint in WMS GetCapabilities response). This comparison was incorrect.

Mapserver computes max scaleHint as:
`scalehintmax = diag*(maxscaledenom/resolution)/msInchesPerUnit(MS_METERS,0);`
with
`diag = sqrt(2.0);`

On the other hand _OpenLayers.Utils.getResolutionFromScale()_ returns:
`resolution = 1 / (normScale * OpenLayers.INCHES_PER_UNIT[units] * OpenLayers.DOTS_PER_INCH);`

There is a sqrt(2.0) ratio between those two values. That's because the scaleHint is based on the diagonal length of a pixel which is sqrt(2.0) longer than its side. See for instance : http://wiki.deegree.org/deegreeWiki/HowToUseScaleHintAndScaleDenominator#What_is_the_ScaleHint.3F

This pull request simply reintroduces the missing sqrt(2.0) ratio in scaleHint/resolution comparisons.
