### PR TITLE
Default projectionCodes is the map projection code

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -97,7 +97,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
      *  ``Array``
      *  List of EPSG codes of projections that should be used when trying to 
      *  recenter on coordinates. Leftmost projections are used preferably.
-     *  Default is ``[4326]``.
+     *  Default is current map projection.
      */
     projectionCodes: null,
 


### PR DESCRIPTION
Plus fix out-of-range coords bad processing.

Done:
- get map projection if no projectionCodes provided
- moved projections detection to viewerReady(), because we can't get the map projection if the viewer is not ready yet
- fixed error (null position) when coords are detected but out of range.

Fix #34
