### PR TITLE
OL layer is not made visible at loading time if no MS layer is checked

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -740,6 +740,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                 group.displayName,
                 this.wmsURL, params, {
                     ref: group.name,
+                    visibility: false,
                     singleTile: true,
                     isBaseLayer: false
                 }
@@ -772,7 +773,9 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         }
 
         layer.setOpacity(opacity || 1);
-        layer.setVisibility(visibility !== 'false');
+        if (layer.params.LAYERS.length > 0) {
+            layer.setVisibility(visibility !== false);
+        }
     },
 
     checkGroupIsAllowed: function(group) {


### PR DESCRIPTION
I am investigating issue #78.

I have found out that in _cgxp.tree.LayerTree.loadGroup()_ [1], if the loaded OpenLayers.Layer has no checked "mapserver" layers (_layer.params.LAYERS = []_), calling _layer.setVisibility()_ at the end of this function will set _layer.params.LAYERS_ to all "mapserver" layers => all subnodes are then checked.

It seems that this behaviour is triggered by a _visibilitychanged_ event in _setVisibility_ [2].

I have not been able to find out what happens when this event is triggered. But anyway it is not necessary to make an OL layer visible if no children is checked. And it seems to fix #78.

[1] https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/widgets/tree/LayerTree.js#L714
[2] https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Layer.js#L743
