### PR TITLE
FeatureGrid - rename the CSV separator option

### DIFF
--- a/core/src/script/CGXP/plugins/FeatureGrid.js
+++ b/core/src/script/CGXP/plugins/FeatureGrid.js
@@ -116,11 +116,11 @@ cgxp.plugins.FeatureGrid = Ext.extend(gxp.plugins.Tool, {
      */
     control: null,
 
-    /** api: config[comma]
+    /** api: config[csvSeparator]
      *  ``String`` Specifies the separator character for the exported
      *  CSV docs. Default is ',' (comma).
      */
-    comma: ',',
+    csvSeparator: ',',
 
     /** api: config[quote]
      *  ``String`` Specifies the character to delimit strings in the
@@ -226,7 +226,7 @@ cgxp.plugins.FeatureGrid = Ext.extend(gxp.plugins.Tool, {
                         }
                     }
                 }
-                csv.push(properties.join(this.comma));
+                csv.push(properties.join(this.csvSeparator));
             }, this);
 
             Ext.Ajax.request({


### PR DESCRIPTION
The name for the CSV separator option is `comma`. This does not make sense. This pull request suggests renaming it to `csvSeparator`.

I know this change breaks the API compat. But who cares? Note that we don't rely on this option in c2cgeoportal (see [this](https://github.com/camptocamp/c2cgeoportal/blob/master/paste_templates/create/%2Bpackage%2B/templates/viewer.js_tmpl#L179)).
