### PR TITLE
add bigger print timeout

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -67,6 +67,12 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      */
     options: null,
 
+    /** api: config[timeout]
+     * ``Integer``
+     * The timeout delay for the print in milliseconds. Default to 2 minutes.
+     */
+    timeout: 120000,
+
     printTitle: "Printing",
     titlefieldText: "Title",
     titlefieldvalueText: "Map title",
@@ -94,6 +100,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
         // create a print provider
         var printProvider = new GeoExt.data.PrintProvider({
             url: this.printURL,
+            timeout: this.timeout,
             baseParams: {
                 url: this.printURL
             },


### PR DESCRIPTION
Many tines the print takes more than 20 seconds and the default timeout is set to 30 segonds ...

Incrase it to 2 minutes and make it configurable.
