### PR TITLE
FeaturesWindow: fix feature id setting when feature comes from a baselayer

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -214,10 +214,14 @@ cgxp.plugins.FeaturesWindow = Ext.extend(gxp.plugins.Tool, {
             feature.attributes.detail = detail.join('');
             feature.attributes.type = OpenLayers.i18n(feature.type); 
 
-            // use the identifierAttribute field if set
-            var identifier = this.layers[feature.type].identifierAttribute;
-            feature.attributes.id = identifier ?
-                feature.attributes[identifier] : feature.id;
+            if (this.layers[feature.type] &&
+                this.layers[feature.type].identifierAttribute) {
+                // use the identifierAttribute field if set
+                var identifier = this.layers[feature.type].identifierAttribute;
+                feature.attributes.id = feature.attributes[identifier];
+            } else {
+                feature.attributes.id = feature.id;
+            }
         }, this);
     },
 


### PR DESCRIPTION
As for now, the new FeaturesWindow plugin assumes that the features it must display are related to overlays. However with CGXP WMTS layers may be queried as well (using the WFSGetFeature plugin).

This pull request prevents the plugin from crashing when features do not come from themes layers. Formerly the following error occured:
`Cannot read property 'identifierAttribute' of undefined (FeaturesWindow.js:218)`
