### PR TITLE
Move layertree-loading-error message to the top of the tree

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -785,7 +785,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     this.themealreadyloadedText,
                 '</div>'
             ].join('');
-            var msg = Ext.DomHelper.append(
+            var msg = Ext.DomHelper.insertBefore(
                 this.body,
                 {
                     html: html,
@@ -794,8 +794,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                 true
             ).fadeIn();
             new Ext.util.DelayedTask(function() {
-                var duration = 3;
-                msg.fadeOut('t', { duration: duration });
+                var duration = 1;
+                msg.fadeOut({ duration: duration });
                 new Ext.util.DelayedTask(function() {
                     // make sure that the message is actually removed
                     // ("remove" option of fadeOut() doesn't seem to work)


### PR DESCRIPTION
Theme-already-loaded-message season 2, sequel of #95

As for now, the message is displayed at the bottom of the layertree but might not be visible if the tree is too high (scrollbar). My client suggests to move the message box to the top (at the place where the new theme would have been loaded). The tree is then moved back up when the message vanishes.

By the way I have fixed the fadeOut config that was incorrect. 
