### PR TITLE
Add support of default options to WMS layers

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -758,7 +758,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     visibility: false,
                     singleTile: true,
                     isBaseLayer: false
-                }, this.wmsOptions || {})
+                }, this.wmsOptions)
             );
 
             var result = {


### PR DESCRIPTION
As for now, `transitionEffect: 'resize'` is only available for WMTS layers, not for WMS layers added through the layertree.
