### PR TITLE
Featureswindow label

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -226,7 +226,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(gxp.plugins.Tool, {
                 var identifier = this.layers[feature.type].identifierAttribute;
                 feature.attributes.id = feature.attributes[identifier];
             } else {
-                feature.attributes.id = OpenLayers.i18n(feature.type) + ' ' + ++i;
+                feature.attributes.id = feature.attributes.type + ' ' + ++i;
             }
         }, this);
     },


### PR DESCRIPTION
As for now, if no identifierAttribute has been found for a given layer, the default title of the returned items is the vector feature id (f.e. "OpenLayers_Feature_Vector_1234"), which is long and not relevant for the user. A client has suggested that we simply number the items. This pull request adds the layername as well.

This client has also asked me if the rows could be initially expanded (not only the groups). Is there a simple solution to do so? 
