### PR TITLE
WFSGetFeature: autoconfig of WFS protocol fails to set features namespace

### DIFF
--- a/core/src/script/CGXP/plugins/WFSGetFeature.js
+++ b/core/src/script/CGXP/plugins/WFSGetFeature.js
@@ -169,12 +169,20 @@ cgxp.plugins.WFSGetFeature = Ext.extend(gxp.plugins.Tool, {
         var protocol = new OpenLayers.Protocol.WFS({
             url: this.WFSURL,
             geometryName: this.geometryName,
-            srsName: this.target.mapPanel.map.getProjection()
+            srsName: this.target.mapPanel.map.getProjection(),
+            formatOptions: {
+                featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+                autoconfig: false
+            }
         });
         var externalProtocol = new OpenLayers.Protocol.WFS({
             url: this.WFSURL + "?EXTERNAL=true",
             geometryName: this.geometryName,
-            srsName: this.target.mapPanel.map.getProjection()
+            srsName: this.target.mapPanel.map.getProjection(),
+            formatOptions: {
+                featureNS: 'http://mapserver.gis.umn.edu/mapserver',
+                autoconfig: false
+            }
         });
         // we overload findLayers to avoid sending requests
         // when we have no sub-layers selected


### PR DESCRIPTION
The following problem has been reported for at least 2 projects using the WFSGetFeature plugin: the first time the query tool is used, only the items of the first featureType are returned (whereas other features might be listed in the WFS response sent by mapserver) ; all the items are correctly displayed the next times the tool is used.

According to investigations mainly made by @sbrunner, we have figured out the autoConfig system used in the OL.Format.GML fails to set the features namespace correctly (in fact set it to null) during the first request (maybe a problem in OL?). As a result the GML parsing is uncomplete. I think it is related to the following code:
https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Format/GML/Base.js#L213

The current pull request makes sure that the namespace is correctly set when creating the protocol.
