### PR TITLE
solve bug in the recent patch for supporting mapserver layergroups in the wfsgetfeature plugin

### DIFF
--- a/core/src/script/CGXP/plugins/WFSGetFeature.js
+++ b/core/src/script/CGXP/plugins/WFSGetFeature.js
@@ -235,7 +235,7 @@ cgxp.plugins.WFSGetFeature = Ext.extend(gxp.plugins.Tool, {
                         var layerGroupsData = this.target.mapPanel.layers.getById(layer.id).data.childLayers;
                         if (layerGroupsData) {
                             for (var j = 0, lenj = layers.length; j < lenj; j++) {
-                                if (layerGroupsData[layers[j]]) {
+                                if (layerGroupsData[layers[j]] && layerGroupsData[layers[j]].length > 0) {
                                     // layer is a layergroup
                                     var layerGroup = layerGroupsData[layers[j]]
                                     for (var k = 0, lenk = layerGroup.length; k < lenk; k++) {


### PR DESCRIPTION
mapserver layers which are not mapserver layergroup will still be listed in the layerGroupsData if they are part of a layertree group, the difference between a mapserver layer and mapserver layergroup will be if their childlayer list is empty or not
this patch add an extra check, which effectively allow to differentiate correctly mapserver layer from mapserver layergroups (tested ok in project Morges) 
