### PR TITLE
New plugin triggering a WFS GetFeature according to permalink parameters

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -197,6 +197,10 @@ cgxp.WFSPermalink = Ext.extend(Ext.Component, {
             return null;
         }
 
+        if (filters.length == 1) {
+            return filters[0];
+        }
+
         return new OpenLayers.Filter.Logical({
             type: OpenLayers.Filter.Logical.AND,
             filters: filters


### PR DESCRIPTION
This plugin detects permalink parameters starting with "wfs_" (by default), looks for a tablename and filtering params, performs a WFS GetFeature request and then passes the returned features to plugins such as FeatureGrid that are responsible to list and display them on the map. The WFS request is made using a process similar to the one in use withe the QueryBuilder plugin.

Example of plugin configuration in viewer.js:

```
    {   
        ptype: "cgxp_wfspermalink",
        componentConfig: {
            WFSURL: "${request.route_url('mapserverproxy', path='')}",
            WFSGetFeatureId: "wfsgetfeature",
            maxFeatures: 10, 
            pointRecenterZoom: 13,
            srsName: 'EPSG:2056',
            events: EVENTS
        }   
    }
```

At the moment, when the FeatureGrid plugin is activated, only the first result is selected in the grid and hilighted on the map. I would need to have the possibility of showing all the results at the same time as well. But cannont access the grid plugin from the WFSPermalink... Maybe some work in the FeatureGrid plugin would be necessary...
