### PR TITLE
WMTS layer source

### DIFF
--- a/core/src/script/CGXP/plugins/SwitchableWMTSSource.js
+++ b/core/src/script/CGXP/plugins/SwitchableWMTSSource.js
@@ -30,6 +30,35 @@
  */
 Ext.namespace("cgxp.plugins");
 
+/** api: example
+ *  Sample code showing how to add a switchable WMTS layer to a Viewer:
+ *
+ *  .. code-block:: javascript
+ *
+ *      new gxp.Viewer({
+ *          ...
+ *          sources: {
+ *              ...
+ *              "switchablewmtssource": {
+ *                  ptype: "cgxp_switchablewmtssource"
+ *              }
+ *          },
+ *          ...
+ *          layers: [{
+ *              source: "switchablewmtssource",
+ *              group: 'background',
+ *              args: [{
+ *                  name: 'foo',
+ *                  layer: 'bar',
+ *                  url: '...',
+ *                  secondaryUrl: '...',
+ *                  zoomThreshold: 10
+ *              }]
+ *          }]
+ *          ...
+ *      });
+ */
+
 /** api: constructor
  *  .. class:: SwitchableWMTSSource(config)
  *


### PR DESCRIPTION
This PR adds WMTS layers as a new source type to CGXP.
At the moment it is quite simple but provide the possibility to switch URL depending on the zoomlevel.
Example of usage:

```
    // layer sources
    sources: {
        "olsource": {
            ptype: "gxp_olsource"
        },  
        "switchablewmtssource": {
            ptype: "cgxp_switchablewmtssource"
        }   
    },
```

```
layers: [{
    source: "switchablewmtssource",
    group: 'background',
    args: [{
        name: 'foo',
        layer: 'bar',
        url: '...',
        secondaryUrl: '...',
        zoomThreshold: 10
    }]
}]
```

I have noticed a closed issue on GXP's GitHub but found no trace of a WMTS source in GXP.
https://github.com/opengeo/gxp/issues/15
