### PR TITLE
Moved metadata action handler into a dedicated method

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -138,7 +138,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
 
         this.actionsPlugin = new GeoExt.plugins.TreeNodeActions({
             listeners: {
-                action: this.onAction
+                action: this.onAction,
+                scope: this
             }
         });
         this.plugins = [
@@ -534,6 +535,17 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
     },
 
     /**
+     * Method: onMetadataAction
+     * Handles a click on the metadata icon
+     *
+     * Parameters:
+     * node {Object}
+     */
+    onMetadataAction: function(node) {
+        window.open(node.attributes.metadataUrl);
+    },
+
+    /**
      * Method: onAction
      * Called when a action image is clicked
      */
@@ -545,7 +557,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         }
         switch (action) {
             case 'metadata':
-                window.open(node.attributes.metadataUrl);
+                this.onMetadataAction(node);
                 break;
             case 'delete':
                 var tree = node.getOwnerTree();


### PR DESCRIPTION
This change allows to customize what happens when the user clicks on the metadataUrl action in the layertree nodes. The default behaviour is to open a new window.

If one wants to do something else (open an Ext.Window for instance), he may override the method or simply pass it in the "outputConfig" param of the layertree plugin in viewer.js. For instance:

```
    {
        ptype: "cgxp_layertree",
        id: "layertree",
        outputConfig: {
            header: false,
            flex: 1,
            layout: "fit",
            autoScroll: true,
            themes: THEMES,
            defaultThemes: ["Default"],
            wmsURL: "${request.route_url('mapserverproxy', path='')}",
            onMetadataAction: function(node) {
                alert(node.attributes.metadataUrl)
            },
            wmsOptions: {
                transitionEffect: "resize"
            }
        },
        outputTarget: "layerpanel"
    },
```
