### PR TITLE
added friendly url rewrite for themes (html5 browser only)

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -737,12 +737,26 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             this.loadGroup(group);
         }, this);
 
+        // change them in url
         if (this.uniqueTheme && this.frienlyUrl && history.replaceState) {
-            // replace anything after theme/ and final / or end
-            var re = /^(.*\/theme\/).*$/;
-            var results = re.exec(String(location.href));
-            var query = location.search != '' ? '/' + location.search : '';
-            var newUrl = results[1] + theme.name + query;
+            var url = location.href;
+            var tpos = url.indexOf('/theme/');
+            var qpos = url.indexOf('?');
+            var query = '';
+            var th = '';
+            var end = url.length;
+            if (tpos > -1) {
+                end = tpos + 7;
+            } else {
+                if (qpos > -1) {
+                    end = qpos;
+                }
+                th = url.substr(end-1, 1) != '/' ? '/theme/' : 'theme/';
+            }
+            if (qpos > -1) {
+                query = url.substr(qpos);
+            }
+            var newUrl = url.substr(0, end) + th + theme.name + query;
             history.replaceState({}, OpenLayers.i18n(theme.name), newUrl);
         }
     },


### PR DESCRIPTION
this allow to rewrite the url of the current page (html5 capable browser only)
it also impact the history, meaning the new url is story by the browser and bookmarking or session reload will use the new url.

at the moment it only work if uniqueTheme is enabled, as there arent any easy way to recover the list of loaded themes (we only have the list of loaded groups). 
it would require a new function to get the theme for a given group.
this was not done as it was not asked, but it's doable if one of our client ask for it.
