### PR TITLE
Add new tools helper function in cgxp

### DIFF
--- a/core/src/script/CGXP/tools/tools.js
+++ b/core/src/script/CGXP/tools/tools.js
@@ -27,14 +27,14 @@ Ext.namespace("cgxp.tools");
 */
 cgxp.tools.openInfoWindow = function(url, title, width, height) {
     var content = {
-            xtype: 'box',
-            autoEl: {
-                tag: 'iframe',
-                src: url,
-                align: 'left',
-                scrolling: 'auto',
-                frameborder: '0'
-            }
+        xtype: 'box',
+        autoEl: {
+            tag: 'iframe',
+            src: url,
+            align: 'left',
+            scrolling: 'auto',
+            frameborder: '0'
+        }
     };
     cgxp.tools.openWindow(content, title, width, height);
 };


### PR DESCRIPTION
After discussing with Stephan about the function made by Pierre to display remote html into Ext Windows, we decided it was better placed in a js file in cgxp than in the viewer.js template in c2cgeoportal.

The namespace has changed a bit from the initial version, from app to cgxp.tool, but I believe it's a relatively benign change for our client who are already using the Ext Windows popup (theorically solved with a sql query to replace the app. by cgxp.tool. in the javascript call)

This also allow to display server error message happening at initial load, see related pull request in c2cgeoportal: 
https://github.com/camptocamp/c2cgeoportal/pull/223
