### PR TITLE
Workaround to avoid jsbuild compression error

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -226,7 +226,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(gxp.plugins.Tool, {
                 var identifier = this.layers[feature.type].identifierAttribute;
                 feature.attributes.id = feature.attributes[identifier];
             } else {
-                feature.attributes.id = feature.attributes.type + ' ' + ++i;
+                feature.attributes.id = feature.attributes.type + ' ' + (++i);
             }
         }, this);
     },


### PR DESCRIPTION
When jsbuild compresses
`
'foobar' + ++i
`
it returns an invalid code:
`
'foobar'+++i
`
