### PR TITLE
Explicitly show tooltip window

### DIFF
--- a/core/src/script/CGXP/widgets/MapPanel.js
+++ b/core/src/script/CGXP/widgets/MapPanel.js
@@ -87,7 +87,7 @@ cgxp.MapPanel = Ext.extend(GeoExt.MapPanel, {
                 map: this.map,
                 unpinnable: false,
                 html: state.tooltip
-            });
+            }).show();
         }
         if (state.crosshair && state.x && state.y) {
             this.getVectorLayer().addFeatures([


### PR DESCRIPTION
or else "map_tooltip" window is not shown (because of some recent change in GeoExt?).
