### PR TITLE
print box not moving when zooming

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -55,9 +55,7 @@ Ext.namespace("cgxp.plugins");
  *                  labelAlign: 'top',
  *                  defaults: {
  *                      anchor: '100%'
- *                  }
- *              },
- *              outputConfig: {
+ *                  },
  *                  autoFit: true
  *              }
  *          }]


### PR DESCRIPTION
We have a regression where the print box/extent does not move when zooming the map. It just sits there and never changes position.

This is caused by a [GXP commit](https://github.com/opengeo/gxp/commit/10a79f9a6a205c68bc2d66084caa1649cc0719c4). In Tool.js:

```
-            Ext.apply(config, this.outputConfig);
+            if (!(config instanceof Ext.Component)) {
+                Ext.apply(config, this.outputConfig);
+            }
```

The print plugin docs advertize to use the following in the plugin config:

```
    outputConfig: {
        autoFit: true
    }
```

But this is incorrect, as the print plugin passes an actual component to `Tool.prototype.addOutput`. Instead `autoFit` should be in the `options` object.

```
    options: {
        labelAlign: 'top',
        defaults: {
            anchor: '100%'
        },
        autoFit: true
    }
```
