### PR TITLE
Don't allow node checkchange on node click. Prevents errors with slider.

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -219,10 +219,6 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
         }, this);
         this.changing = false;
 
-        this.on('click', function(node) {
-            node.getUI().toggleCheck(!node.getUI().isChecked());
-        });
-
         this.mapPanel.map.events.on({
             'zoomend': function() {
                 this.getRootNode().cascade(this.checkInRange);


### PR DESCRIPTION
I suggest we remove the ability for users to change the checkbox status by clicking anywhere on the node.
Closes #40.
