### PR TITLE
Add support of multivalue params in WFSPermalink

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -204,16 +204,29 @@ cgxp.WFSPermalink = Ext.extend(Ext.Component, {
             return null;
         }
         
-        var filters = [], prop;
+        var filters = [], prop, values, propFilters, i, len;
         for (prop in this.filters) {
             if (!this.filters[prop]) {
                 continue;
             }
-            filters.push(new OpenLayers.Filter.Comparison({
-                type: OpenLayers.Filter.Comparison.EQUAL_TO,
-                property: prop,
-                value: this.filters[prop]
-            }));
+            values = this.filters[prop] instanceof Array ?
+                     this.filters[prop] : [this.filters[prop]];
+            propFilters = [];
+            for (i = 0, len = values.length; i < len; i++) {
+                propFilters.push(new OpenLayers.Filter.Comparison({
+                    type: OpenLayers.Filter.Comparison.EQUAL_TO,
+                    property: prop,
+                    value: values[i]
+                }));
+            }
+            if (propFilters.length > 1) {
+                filters.push(new OpenLayers.Filter.Logical({
+                    type: OpenLayers.Filter.Logical.OR,
+                    filters: propFilters
+                }));
+            } else {
+                filters.push(propFilters[0]);
+            }
         }
         
         if (!filters) {


### PR DESCRIPTION
If a WFS search permalink parameter contains several comma-separated values, we use an OR filter to combine those values for the given criteria.
