### PR TITLE
Reintroduce childLayers support in LayerTree, accidentaly dropped in a previous merge

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -994,6 +994,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                 var result = {
                     allLayers: [],
                     checkedLayers: [],
+                    childLayers: null,
                     disclaimer: {}
                 };
                 this.parseChildren(group, layer, result);
@@ -1004,6 +1005,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                 this.mapPanel.layers.insert(index,
                     new this.recordType({
                         disclaimer: result.disclaimer,
+                        childLayers: result.childLayers,
                         layer: layer
                     }, layer.id));
                 groupNode = this.addGroup(group, true);
@@ -1013,6 +1015,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     allLayers: [],
                     checkedLayers: [],
                     disclaimer: {},
+                    childLayers: null,
                     allOlLayers: []
                 };
                 this.indexesToAdd = [];


### PR DESCRIPTION
It seems that commit bc5a8b6acdc accidentally dropped the grouped layers support in the query tool.
