### PR TITLE
Editing - attribute translations in feature window

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -476,6 +476,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
         });
         store.on({
             load: function() {
+                // Remove geometry fields, and add "label" fields for i18n.
                 var geometryType;
                 var geomRegex = /gml:((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry)).*/;
                 store.each(function(r) {
@@ -483,7 +484,6 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                     if (match) {
                         geometryType = match[1];
                         store.remove(r);
-                        return false;
                     }
                     r.set('label', OpenLayers.i18n(r.get('name')));
                 });


### PR DESCRIPTION
Currently, attribute translations in <project>/static/js/Proj/Lang/mylanguage.js are not applied in the editing window which is opened when a feature is added or edited. It would be nice from an UI point of view to be able to translate them.
