### PR TITLE
Fix a bug when no layer is detected while making a WFS GetFeature

### DIFF
--- a/core/src/script/CGXP/plugins/WFSGetFeature.js
+++ b/core/src/script/CGXP/plugins/WFSGetFeature.js
@@ -244,6 +244,9 @@ cgxp.plugins.WFSGetFeature = Ext.extend(gxp.plugins.Tool, {
                         if (Ext.isArray(layers)) {
                             layers = layers.join(',');
                         }
+                        if (!layers) {
+                            return;
+                        }
                         layers = layers.split(',');
                         
                         // replacing layerGroups by child layers and filtering by 


### PR DESCRIPTION
As for now when the current background layer has no "mapserverLayers" param, the WFSGetFeature plugin fails when trying to execute

```
layers = layers.split(',');
```

because "layers" is undefined.
This PR suggests to add a check to ignore the layer when no mapserver layers info are detected.

Please note however that one could get such info using

```
var layers = layer.params.LAYERS || layer.mapserverLayers || layer.layer;
```

instead of

```
var layers = layer.params.LAYERS || layer.mapserverLayers;
```

but I am not sure it is really relevent, for instance if we don't want to query a raster background layer. 
