### PR TITLE
Editing visibility

### DIFF
--- a/core/src/script/CGXP/widgets/MapOpacitySlider.js
+++ b/core/src/script/CGXP/widgets/MapOpacitySlider.js
@@ -203,11 +203,7 @@ cgxp.MapOpacitySlider = Ext.extend(Ext.Toolbar, {
      */
     updateBaseLayer: function(newBaseLayer) {
         if (this.map.allOverlays) {
-            Ext.each(this.layers,
-                function(layer) {
-                    layer.setVisibility(false);
-                }
-            );
+            Ext.invoke(this.layers, "setVisibility", false);
             this.map.setLayerIndex(newBaseLayer, 0);
             newBaseLayer.setVisibility(true);
         } else {


### PR DESCRIPTION
Currently the editing plugin is broken because the editing vector layer visibility is set to false when the mapopacity slider is added.
This is due to the fact that the map opacity slider sets the visibility to false on the first found layer which may not be a background layer in some cases.

This pull request aim is to have a less intrusive base layer change.
Please review.
