### PR TITLE
Print attributes with "featureswindow" plugin

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -274,7 +274,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(gxp.plugins.Tool, {
                 closeAction: 'hide',
                 items: [this.grid],
                 listeners: {
-                    close: function() {
+                    hide: function() {
                         this.store.removeAll();
                     },
                     scope: this

--- a/core/tests/spec/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/tests/spec/script/CGXP/plugins/FeaturesWindow.js
@@ -79,7 +79,7 @@ describe('plugins.FeaturesWindow', function() {
             fw.showWindow([
                 new OpenLayers.Feature.Vector(null, {})
             ]);
-            fw.featuresWindow.close();
+            fw.featuresWindow.hide();
         });
         afterEach(function() {
             fw.featuresWindow.destroy();


### PR DESCRIPTION
When printing from an application with plugin "featureswindow" activated, attributes are always included in output, even if the window containing the results of query is closed. To reproduce : 
1. Go to http://map.cartoriviera.ch
2. Click i button and then click on map -> a window is opened with the results
3. Close the window containing the restults of query
4. Print a map -> the attributes are printed, but they may not 
