### PR TITLE
add possibility to override/customize the way scale values are displayed...

### DIFF
--- a/core/src/script/CGXP/plugins/ScaleChooser.js
+++ b/core/src/script/CGXP/plugins/ScaleChooser.js
@@ -70,15 +70,43 @@ cgxp.plugins.ScaleChooser = Ext.extend(gxp.plugins.Tool, {
      */
     width: 100,
 
+    /** api: config[scaleStoreListeners]
+     *  ``Object``
+     *  Ext listener config to be applied on the scale store
+     *  for example:
+     *  scaleStoreListeners: {
+     *      load: function(store, records, index) {
+     *          store.each(function(record) {
+     *              // bla
+     *          }
+     *      }
+     *  }
+     */
+    scaleStoreListeners: {},
+
+    /** api: config[tpl]
+     *  ``String``
+     *  Ext template to format the scale value in the scale combobox.
+     */
+    tpl: '<tpl for="."><div class="x-combo-list-item">1 : {[parseInt(values.scale)]}</div></tpl>',
+
+    /** api: config[formatValue]
+     *  ``Function``
+     *  Callback function to format the value of the selected scale in the scale combobox.
+     */
+    formatValue: function(scale) {
+        return "1 : " + parseInt(scale.data.scale);
+    },
+
     /** public: method[addActions]
      *  :arg config: ``Object``
      */
     addActions: function(config) {
         var map = this.target.mapPanel.map;
-        var scaleStore = new GeoExt.data.ScaleStore({map: map});
+        var scaleStore = new GeoExt.data.ScaleStore({map: map, listeners: this.scaleStoreListeners});
         var zoomSelector = new Ext.form.ComboBox({
             store: scaleStore,
-            tpl: '<tpl for="."><div class="x-combo-list-item">1 : {[parseInt(values.scale)]}</div></tpl>',
+            tpl: this.tpl,
             editable: false,
             width: this.width,
             triggerAction: 'all', // needed so that the combo box doesn't filter by its current content
@@ -101,7 +129,7 @@ cgxp.plugins.ScaleChooser = Ext.extend(gxp.plugins.Tool, {
     
             if (scale.length > 0) {
                 scale = scale.items[0];
-                zoomSelector.setValue("1 : " + parseInt(scale.data.scale));
+                zoomSelector.setValue(this.formatValue(scale));
             } else {
                 if (!zoomSelector.rendered) return;
                 zoomSelector.clearValue();


### PR DESCRIPTION
... in the scale selector combobox

most of our client dont want to see weird values like "1:283, 1:708, 1:1417, 1:2834" in the scale selector combobox.
these values are calculated automatically and are correct, but are not really nice from a user point of view and all our client using the scale selector are overriding the values in some way or another (Bale is using its own scaleSelector plugin for example, the old sitn website was also overriding the values and it is almost certain they will ask for this possibility about the new c2cgeoportal version) and Morges, which wanted the scalechooser, asked me to see how to do this.

so here is a way to override the default behavior of the scalechooser.

now I was wondering if it would make sens to directly offer a default scale rewriting because Im almost 100% certain all our client will ask to be able to rewrite the value into "human readable form".

with my modification, it is possible to specify in the plugin config the rewriting system to use, for example:

{
    ptype: "cgxp_scalechooser",
    actionTarget: "center.bbar",
    scaleStoreListeners: {
        load: function(store, records, index) {
            store.each(function(record) {
                var scale = record.get('scale');
                if (scale > 100) {
                    if (scale > 700000) {
                        scale = Math.round((scale/1000000))_1000000;
                    } else if (scale < 400000 && scale >200000) {
                        scale = Math.round((scale/400000))_400000
                    } else if (scale < 200000 && scale >100000) {
                        scale = Math.round((scale/200000))_200000;
                    } else if (scale < 100000 && scale >30000) {
                        scale = Math.round((scale/80000))_80000;
                    } else if (scale < 30000 && scale >15000) {
                        scale = Math.round((scale/40000))_40000;
                    } else if (scale < 15000 && scale >9000) {
                        scale = Math.round((scale/20000))_20000;
                    } else if (scale < 9000 && scale >7000) {
                        scale = Math.round((scale/10000))_10000;
                    } else if (scale < 7000 && scale >5000) {
                        scale = Math.round((scale/8000))_8000;
                    } else if (scale < 5000 && scale >3000) {
                        scale = Math.round((scale/6000))_6000;
                    } else if (scale < 3000 && scale >2000) {
                        scale = Math.round((scale/4000))_4000;
                    } else if (scale < 2000 && scale >900) {
                        scale = Math.round(scale/2000)_2000;
                    } else if (scale < 900 && scale >500) {
                        scale = Math.round((scale/10)/100)_1000;
                    } else if (scale < 500 && scale >300) {
                        scale = Math.round((scale/10)/50)_500;
                    } else if (scale < 300) {
                        scale = Math.round((scale/10)/25)_250;
                    }
                }
                scale = "1 : " + OpenLayers.Number.format(scale, 0, "'");
                record.set('scale', scale);
            }); 
        }
    },
    tpl: '<tpl for="."><div class="x-combo-list-item">{[values.scale]}</div></tpl>',
    formatValue: function(scale) {
        return scale.data.scale;
    }
}

live example visible there:
http://c2cpc34.camptocamp.com/admin/wsgi/?debug

comment plz
