### PR TITLE
Adding TMS layers to WFSGetFeature

### DIFF
--- a/core/src/script/CGXP/plugins/WFSGetFeature.js
+++ b/core/src/script/CGXP/plugins/WFSGetFeature.js
@@ -240,6 +240,9 @@ cgxp.plugins.WFSGetFeature = Ext.extend(gxp.plugins.Tool, {
                     olLayers = olLayers.concat(
                         this.map.getLayersByClass("OpenLayers.Layer.WMTS")
                     );
+                    olLayers = olLayers.concat(
+                        this.map.getLayersByClass("OpenLayers.Layer.TMS")  
+                    );
                 }
                 var internalLayers = [];
                 var externalLayers = [];


### PR DESCRIPTION
As SITN is mostly using TMS layers as background layers, we would like to add TMS to the WFSGetFeature queryable types (we plan to migrate to WMTS, but only in long term).

See issue 24 in the <a href="https://github.com/camptocamp/sitn_c2cgeoportal/issues/24" target=_blank>sitn_c2cgeoportal</a> project.

Any better idea welcome.
