### PR TITLE
Add an optional WMS service list to the WMS browser

### DIFF
--- a/core/src/script/CGXP/plugins/WMSBrowser.js
+++ b/core/src/script/CGXP/plugins/WMSBrowser.js
@@ -90,7 +90,13 @@ cgxp.plugins.WMSBrowser = Ext.extend(gxp.plugins.Tool, {
      *  Config object for the action created by this plugin.
      */
     actionConfig: null,
-
+    
+    /** api: config[serverStore]
+    * ``Array(String)``
+    * The list of WMS services to be displayed in the layer combobox.
+    */
+    serverStore: null,
+    
     /** private: method[addActions]
      */
     addActions: function() {
@@ -155,6 +161,12 @@ cgxp.plugins.WMSBrowser = Ext.extend(gxp.plugins.Tool, {
                     scope: this
                 } : {}
             };
+            if (this.serverStore) {
+                config.serverStore = new Ext.data.SimpleStore({
+                    fields: ['url'],
+                    data: this.serverStore
+                });
+            }
             this.wmsBrowser = new GeoExt.ux.WMSBrowser(config);
         }
         return this.wmsBrowser;


### PR DESCRIPTION
If `serverStore` is defined as an optional array containing WMS service URLs in `<my_project>\templates\viewer.js`, then the textfield is converted to a combobox enabling a simpler selection of WMS services.

An example of an array as `serverStore` option in the `cgxp_wmsbrowser` plugin:

``` javascript
serverStore: [
    'http://wms.geo.admin.ch/?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.0.0&lang=fr',
    'http://cartoserver.vd.ch/ogcccgeo/wms?'
]
```
