### PR TITLE
Always use geodesic:true for measure controls?

### DIFF
--- a/core/src/script/CGXP/plugins/Measure.js
+++ b/core/src/script/CGXP/plugins/Measure.js
@@ -308,6 +308,7 @@ cgxp.plugins.Measure = Ext.extend(gxp.plugins.Tool, {
         ]);
         var styleMap = new OpenLayers.StyleMap({"default": style});
         var control = new cgxp.plugins.Measure.SegmentMeasureControl({
+            geodesic: true,
             elevationServiceUrl: this.elevationServiceUrl,
             handlerOptions: {
                 layerOptions: {styleMap: styleMap}


### PR DESCRIPTION
The measure plugin's uses `geodesic:true` by default for the length and area controls, while it uses `geodesic:false` for the segment control. While this doesn't seem to be a problem for maps that use the swiss projection (EPSG:21781), it is a problem for maps that use spherical mercator. In the latter case, the distance value provided by the segment control is incorrect.
