### PR TITLE
WMSLegend fixes

### DIFF
--- a/core/src/script/CGXP/widgets/WMSLegend.js
+++ b/core/src/script/CGXP/widgets/WMSLegend.js
@@ -65,6 +65,14 @@ cgxp.WMSLegend = Ext.extend(GeoExt.WMSLegend, {
                 originalUpdate.apply(this, arguments);
             }.createDelegate(this), this.updateDelay);
         }.createDelegate(this);
+    },
+
+    beforeDestroy: function() {
+        if (this._timeoutId) {
+            window.clearTimeout(this._timeoutId);
+            delete this._timeoutId;
+        }
+        cgxp.WMSLegend.superclass.beforeDestroy.call(this);
     }
 });
 

--- a/core/tests/spec/script/CGXP/widgets/WMSLegend.js
+++ b/core/tests/spec/script/CGXP/widgets/WMSLegend.js
@@ -32,4 +32,14 @@ describe('cgxp.WMSLegend', function() {
             expect(updateSpy).toHaveBeenCalled();
         });
     });
+
+    describe('destroy', function() {
+
+        it('clears the update legend timeout', function() {
+            legend.update();
+            legend.destroy();
+            clock.tick(10);
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
This PR fixes two issues related to the new WMSLegend:
- Registers cgxp_wmslegend as a print legends encoder
- Clears the legend update timeout on destroy

Please review.
