### PR TITLE
${} instead of $${} in the doc strings

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -48,7 +48,7 @@ Ext.namespace("cgxp.plugins");
  *          tools: [{
  *              ptype: 'cgxp_editing',
  *              layerTreeId: 'layertree',
- *              layersURL: "$${request.route_url('layers_root')}"
+ *              layersURL: "${request.route_url('layers_root')}"
  *          }, {
  *              ptype: "cgxp_layertree",
  *              id: "layertree",

--- a/core/src/script/CGXP/plugins/FeatureGrid.js
+++ b/core/src/script/CGXP/plugins/FeatureGrid.js
@@ -51,7 +51,7 @@ Ext.namespace("cgxp.plugins");
  *          tools: [{
  *              ptype: "cgxp_featuregrid",
  *              id: "featureGrid",
- *              csvURL: "$${request.route_url('csvecho')}",
+ *              csvURL: "${request.route_url('csvecho')}",
  *              maxFeatures: 200,
  *              outputTarget: "featuregrid-container",
  *              events: EVENTS

--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -40,7 +40,7 @@ Ext.namespace("cgxp.plugins");
  *          ...
  *          tools: [{
  *              ptype: "cgxp_fulltextsearch",
- *              url: "$${request.route_url('fulltextsearch', path='')}",
+ *              url: "${request.route_url('fulltextsearch', path='')}",
  *              actionTarget: "center.tbar"
  *          }]
  *          ...

--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -42,7 +42,7 @@ Ext.namespace("cgxp.plugins");
  *          ...
  *          tools: [{
  *              ptype: "cgxp_wfspermalink",
- *              WFSURL: "$${request.route_url('mapserverproxy', path='')}",
+ *              WFSURL: "${request.route_url('mapserverproxy', path='')}",
  *              WFSGetFeatureId: "wfsgetfeature",
  *              maxFeatures: 10,
  *              pointRecenterZoom: 13,


### PR DESCRIPTION
`viewer.js` in c2cgeoportal applications is not a `.in` file, it is just a Mako template, so we use `${}` instead of `$${}`.
