### PR TITLE
Add vectorLayerConfig to FullTextSearch

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -135,7 +135,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
 
     projections: null,
 
-    /** api_ config[vectorLayerConfig]
+    /** api: config[vectorLayerConfig]
      *  ``Object``
      *  Optional configuration of the vector layer.
      */


### PR DESCRIPTION
This is use full to have this kind of config: 

```
{
    ptype: 'cgxp_fulltextsearch',
    ...,
    vectorLayerConfig: {
        style: {
            pointRadius: 18,
            externalGraphic: OpenLayers.ImgPath + 'marker.gif'
        }
    }
}
```
