### PR TITLE
themes.external may be not set, so we need to provide a default empty in...

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -167,7 +167,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(gxp.plugins.Tool, {
                 }
             }
         }
-        browseThemes(this.themes.external | {});
+        browseThemes(this.themes.external || {});
         browseThemes(this.themes.local);
         this.layers = layers;
     },


### PR DESCRIPTION
... this case, otherwise it breaks in the browseThemes method

tested in project pully_geoportal
