### PR TITLE
Add config for legend checkbox initial status

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -156,7 +156,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      */
     addOutput: function(config) {
         
-        this.includeLegend = this.checkLegend && !!(this.legendPanelId);
+        this.includeLegend = this.checkLegend && !!this.legendPanelId;
 
         // create a print provider
         var printProvider = new GeoExt.data.PrintProvider({
@@ -434,7 +434,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                 boxLabel: this.includelegendText,
                 checked: this.includeLegend,
                 // deactivate the checkbox if no legend panel is available
-                hidden: !(this.legendPanelId), 
+                hidden: !this.legendPanelId, 
                 handler: function(cb, checked) {
                     this.includeLegend = checked;
                 },


### PR DESCRIPTION
As for now, the legend checkbox is always checked by default in the print form. This PR adds a config parameter to change the default status of the checkbox.
