### PR TITLE
WFSGetFeature: name attribute is used with queryLayers

### DIFF
--- a/core/src/script/CGXP/plugins/WFSGetFeature.js
+++ b/core/src/script/CGXP/plugins/WFSGetFeature.js
@@ -371,7 +371,7 @@ cgxp.plugins.WFSGetFeature = Ext.extend(gxp.plugins.Tool, {
                             }
                         }
                     } else if (inRange(layers[j], currentRes)) {
-                        filteredLayers.push(layers[j]);
+                        filteredLayers.push(layers[j].name || layers[j]);
                     }
                 }
 


### PR DESCRIPTION
Make sure that the layer name is correctly retrieved whereas the layer comes from "mapserverLayers" or "queryLayers".  #282 has broken the support of queryLayers.
