### PR TITLE
FullTextSearch: enable client-side sorting only when grouping is on

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -207,7 +207,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
             reader: new cgxp.data.FeatureReader({
                 format: new OpenLayers.Format.GeoJSON()
             }, ['label', 'layer_name']),
-            sortInfo: {field: 'layer_name', direction: 'ASC'}
+            sortInfo: this.grouping ? {field: 'layer_name', direction: 'ASC'} : null
         });
 
         store.on('beforeload', function(store, options) {


### PR DESCRIPTION
If some sorting has already been performed server-side, it is no use adding a "sortInfo" param to the FTS store.

I have only tested with "grouping: false".
