### PR TITLE
FullTextSearch sets partitionlimit in query if grouping enabled

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -196,14 +196,14 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
     },
 
     createStore: function() {
+        var baseParams = this.grouping ? {limit: 40, partitionlimit: 10} :
+                                         {limit: 20};
         var store = new GeoExt.data.FeatureStore({
             proxy: new Ext.data.ScriptTagProxy({
                 url: this.url,
                 callbackParam: 'callback'
             }),
-            baseParams: {
-                "limit": 20
-            },
+            baseParams: baseParams,
             reader: new cgxp.data.FeatureReader({
                 format: new OpenLayers.Format.GeoJSON()
             }, ['label', 'layer_name']),


### PR DESCRIPTION
If `grouping` is true a `partitionlimit` value is set in the query string of the text search request. This parameter enables limiting the number of results per layer/group instead of globally only.

This is based on https://github.com/camptocamp/c2cgeoportal/pull/427.

(Tested on my SITN instance.)
