### PR TITLE
Extend support of OSM and Google sources to CGXP's needs

### DIFF
--- a/core/src/script/CGXP/plugins/GoogleSource.js
+++ b/core/src/script/CGXP/plugins/GoogleSource.js
@@ -57,10 +57,8 @@ Ext.namespace("cgxp.plugins");
  *    {
  *        source: "google",
  *        name: "TERRAIN",
- *        layerOptions: {
- *            ref: "google_terrain",
- *            group: "background"
- *        }
+ *        ref: "google_terrain",
+ *        group: "background"
  *    }
  */
 cgxp.plugins.GoogleSource = Ext.extend(gxp.plugins.GoogleSource, {
@@ -77,7 +75,15 @@ cgxp.plugins.GoogleSource = Ext.extend(gxp.plugins.GoogleSource, {
     createLayerRecord: function(config) {
         var record = cgxp.plugins.GoogleSource.superclass
                          .createLayerRecord.apply(this, arguments);
-        Ext.apply(record.data.layer, config.layerOptions);
+        if (record) {
+            var layer = record.getLayer();
+            if (config.group) {
+                layer.group = config.group;
+            }
+            if (config.ref) {
+                layer.ref = config.ref;
+            }
+        } 
         return record;
     }
 });

--- a/core/src/script/CGXP/plugins/OSMSource.js
+++ b/core/src/script/CGXP/plugins/OSMSource.js
@@ -54,10 +54,8 @@ Ext.namespace("cgxp.plugins");
  *    {
  *        source: "osm",
  *        name: "mapnik"
- *        layerOptions: {
- *            ref: "mapnik",
- *            group: "background"
- *        }
+ *        ref: "mapnik",
+ *        group: "background"
  *    }
  */
 cgxp.plugins.OSMSource = Ext.extend(gxp.plugins.OSMSource, {
@@ -74,7 +72,15 @@ cgxp.plugins.OSMSource = Ext.extend(gxp.plugins.OSMSource, {
     createLayerRecord: function(config) {
         var record = cgxp.plugins.OSMSource.superclass
                          .createLayerRecord.apply(this, arguments);
-        Ext.apply(record.data.layer, config.layerOptions);
+        if (record) {
+            var layer = record.getLayer();
+            if (config.group) {
+                layer.group = config.group;
+            }
+            if (config.ref) {
+                layer.ref = config.ref;
+            }
+        }
         return record;
     }
 });


### PR DESCRIPTION
The main purpose of this PR is to add support of an additional "options" param to those 2 GXP source plugins. For instance to provide them the group/ref params so that they can be used in the mapopacityslider plugin:

```
           {
                source: "osm",
                name: "mapnik",
                group: 'background',
                ref: 'osm'
            }

```
