### PR TITLE
z-index of Ext.Window

### DIFF
--- a/core/src/theme/all.css
+++ b/core/src/theme/all.css
@@ -4,10 +4,6 @@ div.x-panel a {
 div.x-panel a:hover {
     text-decoration: underline;
 }
-div#header-out {
-    position: relative;
-    z-index: 20001;
-}
 .app-accordion-body {
     padding: 3px;
 }


### PR DESCRIPTION
When moving an Ext.Window over the top banners, these are positioned under the banner images (z-index). Therefore, the windows cannot be closed or moved anymore.

@ochriste reported also this issue (but I don't know for which project) (see https://github.com/camptocamp/cgxp/issues/272#issuecomment-10320847)

Tested and buging on the following instances:
- SITN (http://sitn.ne.ch/sitn_dev/wsgi/), use the window opened by clicking on "contact" for instance
- GeoView BL (http://geoview.bl.ch/), use the legend window for instance

Tested and not buging:
- Cartoriviera (http://map.cartoriviera.ch/theme/Cadastre), use the legend window for instance
- Morges (http://c2cpc34.camptocamp.com/admin/wsgi/), use the permalink window for instance
- Pully (http://sigip.ch/)
