### PR TITLE
Window layout bug with redlining

### DIFF
--- a/core/src/script/CGXP/plugins/Redlining.js
+++ b/core/src/script/CGXP/plugins/Redlining.js
@@ -91,7 +91,6 @@ cgxp.plugins.Redlining = Ext.extend(gxp.plugins.Tool, {
 
     /* i18n*/
     redliningText: "Redlining",
-    attributesText: 'Attributes',
 
     init: function() {
         cgxp.plugins.Redlining.superclass.init.apply(this, arguments);
@@ -187,6 +186,7 @@ GeoExt.ux.form.FeaturePanel.prototype.labelFieldText = "Label";
 GeoExt.ux.form.FeaturePanel.prototype.colorFieldText = "Color";
 GeoExt.ux.form.FeaturePanel.prototype.strokeWidthFieldText = "Stroke width";
 GeoExt.ux.form.FeaturePanel.prototype.fontSizeFieldText = "Size";
+GeoExt.ux.form.FeaturePanel.prototype.attributesText = "Attributes";
 
 // some more redlining patch
 GeoExt.ux.form.FeaturePanel.prototype.initMyItems = function() {


### PR DESCRIPTION
In the new version 1.2 of C2CGeoportal, there is a bug in the window that appears after having drawn an object. To reproduce :  

1°/ Go to http://preprod.cartoriviera.ch with Firefox (what else...? ;O)
2°/ Click on "Dessin" on top right of map
3°/ Select a tool to draw (point, line, polygon, etc.)
4°/ Draw object on map > a window appears, but there is a horizontal scrolling bar in the color part, and it should not. With IE and Chrome, there is no scrolling bar, but the color part is not complete

Thanks !
