### PR TITLE
Add plugin displaying the mouse cursor coordinates in a toolbar

### DIFF
--- a/core/src/script/CGXP/plugins/MouseCoordinates.js
+++ b/core/src/script/CGXP/plugins/MouseCoordinates.js
@@ -41,7 +41,7 @@ Ext.namespace("cgxp");
  *              ptype: 'cgxp_mousecoordinates',
  *              actionTarget: 'center.bbar',
  *              controlConfig: {
- *                  numDigits: 0,
+ *                  numDigits: 6,
  *                  prefix: 'Lon: ',
  *                  separator: ', lat: ',
  *                  displayProjection: "EPSG:4326"


### PR DESCRIPTION
This plugin is based upon a plugin added by @kalbermattenm in SITN.
