### PR TITLE
Add CGXP-specific class to measure menu

### DIFF
--- a/core/src/script/CGXP/plugins/Measure.js
+++ b/core/src/script/CGXP/plugins/Measure.js
@@ -46,7 +46,10 @@ Ext.namespace("cgxp.plugins");
 /** api: constructor
  *  .. class:: Measure(config)
  *
- *    Provides two actions for measuring length and area.
+ *    This plugin adds a menu with menu items for selecting measure tools.
+ *
+ *    The menu div is assigned the ``cgxp-menu-measure`` class name, which
+ *    can be useful for styling.
  */
 cgxp.plugins.Measure = Ext.extend(gxp.plugins.Tool, {
 
@@ -455,6 +458,7 @@ cgxp.plugins.Measure = Ext.extend(gxp.plugins.Tool, {
                 }
             },
             menu: new Ext.menu.Menu({
+                cls: 'cgxp-menu-measure',
                 items: [
                     new Ext.menu.CheckItem(
                         new GeoExt.Action({


### PR DESCRIPTION
This PR suggests adding a class to the measure menu. This makes it possible to style the menu and its items. This is needed for SITN, see https://github.com/camptocamp/sitn_c2cgeoportal/issues/58.
