### PR TITLE
Add a Geonames search combo plugin

### DIFF
--- a/core/src/script/CGXP/plugins/Geonames.js
+++ b/core/src/script/CGXP/plugins/Geonames.js
@@ -17,6 +17,8 @@
 
 /**
  * @requires plugins/Tool.js
+ * @include OpenLayers/BaseTypes/LonLat.js
+ * @include OpenLayers/Projection.js
  */
 
 /** api: (define)


### PR DESCRIPTION
A port of GeonamesSearchCombo from MapFishAPI:
http://www.mapfish.org/svn/mapfish/contribs/mapfish-api/trunk/MapFishApi/js/GeonamesSearchCombo.js

(I don't know if the 

```
this.view.on('beforeclick', function(view, index, node, event) {
            this.lastTarget = event.getTarget();
        }, this);
```

code in the old MapFishAPI object is really necessary?)

I wonder if this plugin should be integrated in the FullTextSearch plugin since it is quite similar and that interesting features from the latter plugin (support of coordinates for instance) would be useful here as well. On the other hand I find the FullTextSearch plugin already quite complicated...
