### PR TITLE
QueryBuilder returns an array whereas the FeatureGrid expects an object

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -279,9 +279,8 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                     alert(this.errorText);
                     return;
                 }
-                var l = response.features.length;
-                if (response.features && l) {
-                    var fs = response;
+                if (response.features && response.features.length) {
+                    var fs = response, l = fs.features.length;
                     // required by ResultsPanel:
                     while(l--) {
                         fs.features[l].type = this.protocol.featureType;


### PR DESCRIPTION
It seems that in recent versions of FeatureGrid and FeaturesWindow, those plugins expect a "queryResults" as an object containing a "features" properties. But the QueryBuilder still returns an array of features. 
