### PR TITLE
Change type of 'queryresults' event argument in WFSPermalink

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -264,7 +264,7 @@ cgxp.plugins.WFSPermalink = Ext.extend(gxp.plugins.Tool, {
                 this.target.mapPanel.map.zoomTo(this.pointRecenterZoom);
             }
 
-            this.events.fireEvent('queryresults', features, true);
+            this.events.fireEvent('queryresults', {'features': features}, true);
         }
     }
 });


### PR DESCRIPTION
Argument of "queryresults" event has been switched from array to object in some earlier PRs. The change has been omitted in the WFSPermlink plugin.
