### PR TITLE
Add support of an optional printProviderConfig parameter

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -113,7 +113,23 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
 
     printPanel: null,
 
+    /** api: config[mapserverURL]
+     *  ``String``
+     *  URL of the mapserver proxy.
+     */
     mapserverURL: null,
+
+    /** api: config[printURL]
+     *  ``String``
+     *  URL of the print proxy.
+     */
+    printURL: null,
+
+    /** api: config[printProviderConfig]
+     *  ``Object``
+     *  Optional parameters to send to the print proxy.
+     */
+    printProviderConfig: null,
 
     /** api: config[options]
      *  ``String``
@@ -287,9 +303,9 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
         var printProvider = new GeoExt.data.PrintProvider({
             url: this.printURL,
             timeout: this.timeout,
-            baseParams: {
+            baseParams: Ext.apply({
                 url: this.printURL
-            },
+            }, this.printProviderConfig),
             listeners: {
                 beforedownload: function(pp, url) {
                     if (Ext.isIE) {


### PR DESCRIPTION
Sometimes it can be useful to send additional parameters to the print proxy. This PR suggests to add an optional `printProviderConfig` in CGXP's Print plugin config as in the following example:

```
    {   
        ptype: "cgxp_print",
        legendPanelId: "legendPanel",
        featureProvider: "featureGridBL",
        outputTarget: "left-panel",
        printURL: "${request.route_url('printproxy', path='')}",
        mapserverURL: "${mapserverProxyUrl}", 
        checkLegend: false,
        % if 'anonymous' in request.params:
        printProviderConfig: {
            anonymous: true
        },  
        % endif
        options: {
            labelAlign: 'top',
            defaults: {
                anchor:'100%'
            },  
            autoFit: true
        }   
    }
```
