### PR TITLE
Add support of groups of filters in WFSPermalink

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -233,7 +233,7 @@ cgxp.plugins.WFSPermalink = Ext.extend(gxp.plugins.Tool, {
                     filterGroups.push(filter);
                 }
             }
-            if (!filterGroups) {
+            if (filterGroups.length == 0) {
                 return null;
             }
             if (filterGroups.length == 1) {
@@ -278,7 +278,7 @@ cgxp.plugins.WFSPermalink = Ext.extend(gxp.plugins.Tool, {
             }
         }
 
-        if (!filters) {
+        if (filters.length == 0) {
             return null;
         }
 


### PR DESCRIPTION
Using the WFSPermalink plugin, it is possible to make the application show some vector features of a given layer at loading time. The plugin uses the URL parameters to build  a WFS request on a "AND" basis.

For instance http://example.com?wfs_layer=parcels&wfs_city=Oslo&wfs_number=12,34,56 will load parcels 12, 34 and 56 of the city of Oslo.

As for now, GET parameters interact on a "AND" basis.

The present PR add the possibility to define several groups of parameters, allowing for instance to get some parcels from a one city as well as some others from an other city.

A new optional `wfs_ngroups` parameter is added and used to figure out how many groups are defined. Parameters from those groups should be prefixed by the number of each group, starting at 0.

For example:
http://example.com?wfs_layer=parcels&wfs_ngroups=2&wfs_0_city=Oslo&wfs_0_number=12,34,56&wfs_1_city=Paris&wfs_1_number=78,90
