### PR TITLE
Make sure requested basemap exists before activating it

### DIFF
--- a/core/src/script/CGXP/widgets/MapOpacitySlider.js
+++ b/core/src/script/CGXP/widgets/MapOpacitySlider.js
@@ -235,7 +235,9 @@ cgxp.MapOpacitySlider = Ext.extend(Ext.Toolbar, {
      */
     applyState: function(state) {
         var baselayer = this.map.getLayersBy('ref', state.ref)[0];
-        this.updateBaseLayer(baselayer);
+        if (baselayer) {
+            this.updateBaseLayer(baselayer);
+        }
         if (this.orthoRef) {
             var orthoLayer = this.map.getLayersBy('ref', this.orthoRef)[0]
             if (state.opacity != 100) {


### PR DESCRIPTION
If a user loads a permalink with an invalid `baselayer_ref` parameter, the MapOpacitySlider widget fails and no basemap is displayed. This PR checks that the requested basemap is valid before trying to load it.
