### PR TITLE
GetFeature Bug

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -495,7 +495,7 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
             self.events.fireEvent('querystarts');
 
             var olLayers = self.target.mapPanel.map.
-                        getLayersByClass("OpenLayers.Layer.WMS");
+                    getLayersByClass("OpenLayers.Layer.WMS");
             var params = {};
             if (olLayers.length > 0) {
                 var layer = olLayers[0];


### PR DESCRIPTION
I think that PR #430 broke the WFS interrogation.

Line 497 of `GetFeature.js` calls `this.target`, but the scope isn't the right one.

Instead I propose to directly use the map property which is passed to the `buildWFSControls` function.

Please review.
