### PR TITLE
LayerTree fires loadtheme events

### DIFF
--- a/core/src/script/CGXP/plugins/LayerTree.js
+++ b/core/src/script/CGXP/plugins/LayerTree.js
@@ -155,6 +155,18 @@ cgxp.plugins.LayerTree = Ext.extend(gxp.plugins.Tool, {
      */
     tree: null,
 
+    /** private: method[constructor]
+     */
+    constructor: function(config) {
+        cgxp.plugins.LayerTree.superclass.constructor.call(this, config);
+        this.addEvents(
+            /** api: event[loadtheme]
+             *  Fired when a theme is loaded.
+             */
+            "loadtheme"
+        );
+    },
+
     /** private: method[init]
      */
     init: function() {
@@ -183,6 +195,7 @@ cgxp.plugins.LayerTree = Ext.extend(gxp.plugins.Tool, {
         }, config || {});
 
         this.tree = cgxp.plugins.LayerTree.superclass.addOutput.call(this, config);
+        this.relayEvents(this.tree, ['loadtheme']);
         return this.tree;
     }
 

--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -234,7 +234,12 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             /** private: event[ordergroup]
              *  Fires after the themes order is changed.
              */
-            "ordergroup"
+            "ordergroup",
+
+            /** private: event[loadtheme]
+             *  Fires after a theme is loaded.
+             */
+            "loadtheme"
         );
         this.on('checkchange', function(node, checked) {
             this.fireEvent("layervisibilitychange");
@@ -1056,6 +1061,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             var newUrl = url.substr(0, end) + th + theme.name + query;
             history.replaceState({}, OpenLayers.i18n(theme.name), newUrl);
         }
+
+        this.fireEvent('loadtheme', theme);
     },
 
     /** api: method[loadGroup]


### PR DESCRIPTION
The LayerTree plugin fires a loadtheme event when a theme is loaded in the tree.
