### PR TITLE
GetFeature and WMTS

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -851,8 +851,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                                 dimension: child.dimension,
                                 visibility: child.isChecked,
                                 isBaseLayer: false,
-                                mapserverURL: child.mapserverURL,
-                                mapserverLayers: child.mapserverLayers
+                                mapserverURL: child.wmsUrl,
+                                mapserverLayers: child.wmsLayers
                             }, this.wmtsOptions || {}));
                             child.node.attributes.layer = layer;
                             if (this.initialState && this.initialState['opacity_' + child.name]) {


### PR DESCRIPTION
It seems that we have lost the ability to do WFS/WMS requests on WMTS which are included in the layertree.

WMTS layers can be queryable when defined as background layers (mapopacity slider) without any problem.

But if one defines a WMTS in the admin UI and adds a WMS layer as option, nothing happens when trying to do a request, because the `LAYERS` parameter in empty.

Hereunder an snapshot of my layer's config. You can test that on http://sitn.ne.ch/sitn_dev/wsgi/theme/cadastre?map_x=553100&map_y=199200&map_zoom=8.

Just make a stupid click into the map... (the `parcelles` layer was already in use and successfully returned a response for a former WMTS background layer)

Did I miss something, or is that a bug???

![snap](https://f.cloud.github.com/assets/1681332/390910/5980b912-a751-11e2-8ebb-79ed4e1f3276.png)
