### PR TITLE
Fix js error when no query results found

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -385,9 +385,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(cgxp.plugins.FeaturesResult, {
             this.featuresWindow.doLayout();
         }
 
-        if (features.length > 0) {
-            this.featuresWindow.show();
-        }
+        this.featuresWindow.show();
 
         // append new features to existing features in the store
         this.store.loadData(features, true);


### PR DESCRIPTION
this js error appears only when the first query does not return any result.
