### PR TITLE
Parameter for max number of attributes cols while printing

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesGrid.js
+++ b/core/src/script/CGXP/plugins/FeaturesGrid.js
@@ -240,11 +240,6 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
      */
     showUnqueriedLayers: true,
 
-    /** api: config[maxPrintedColumns]
-     *  ``Int`` max number of columns in the printed attributes table. Default is 9.
-     */
-    maxPrintedColumns: 9,
-
     /** private: property[selectAll]
      */
 
@@ -371,9 +366,6 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
                             var id = 'col' + index;
                             raw[id] = attributes[prop];
                             index++;
-                            if (index > this.maxPrintedColumns) {
-                                break;
-                            }
                             if (groupedRecords[grid.title]._newGroup) {
                                 groupedRecords[grid.title][id] = OpenLayers.i18n(prop);
                                 groupedRecords[grid.title].table.columns.push(id);

--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -172,11 +172,6 @@ cgxp.plugins.FeaturesWindow = Ext.extend(cgxp.plugins.FeaturesResult, {
      */
     showUnqueriedLayers: true,
 
-    /** api: config[maxPrintedColumns]
-     *  ``Int`` max number of columns in the printed attributes table. Default is 9.
-     */
-    maxPrintedColumns: 9,
-
     /** api: config[openFeatures]
      *  ``Number`` on add feature directly open the first features, default is 1,
      *  than the first feature is open, others are closed.
@@ -567,9 +562,6 @@ cgxp.plugins.FeaturesWindow = Ext.extend(cgxp.plugins.FeaturesResult, {
                     var id = 'col' + index;
                     raw[id] = attributes[prop];
                     index++;
-                    if (index > this.maxPrintedColumns) {
-                        break;
-                    }
                     if (groupedRecords[attributes.type]._newGroup) {
                         if (prop == this.originalIdRef) {
                             prop = 'id';


### PR DESCRIPTION
Attributes tables printed in the PDF/PNG output are always limited to 9 columns, even if additional columns are added to the "columnDefs" in `print/config.yaml` (by the way the standard print config has a col range going from "col0" to "col9", which makes 10 columns).

The reason of this behaviour is that plugins FeaturesGrid and FeaturesWindow have an hard-coded limitation to 9 cols:

```
                    for (var prop in attributes) {
                        if (attributes.hasOwnProperty(prop)) {

                            var id = 'col' + index;
                            raw[id] = attributes[prop];
                            index++;
                            if (index > 9) {
                                break;
                            }
                            if (groupedRecords[grid.title]._newGroup) {
                                groupedRecords[grid.title][id] = OpenLayers.i18n(prop);
                                groupedRecords[grid.title].table.columns.push(id);
                            }
                        }
                    }
```

See https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/plugins/FeaturesGrid.js#L364

The present PR suggests to replace this hard-coded value by a `maxPrintedColumns` parameter that defaults to 9 and can be set in the plugin's config. For instance:

```
    { 
        ptype: "cgxp_featuresgrid",
        id: "featureGridBL",
        featureManager: "featuremanager",
        csvURL: "${request.route_url('csvecho')}",
        maxFeatures: 200, 
        themes: THEMES,
        outputTarget: "featuregrid-container",
        maxPrintedColumns: 11,
        events: EVENTS
    }
```

On the other hand I have tried to completely remove the `index > 9` test and it seems to work fine with layers coming with whatever number of attributes. The final number of printed attributes is then only configured in `print/config.yaml` which seems more relevent.

Is there a good reason to keep this test in FeaturesGrid and FeaturesWindow?
