### PR TITLE
parse layer children when listing layers to query

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -239,8 +239,14 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                 var child = node[i];
                 if (child.children) {
                     browse(child.children, config);
-                } else {
+                }
+                else {
                     config[child.name] = child;
+                    if (child.childLayers && child.childLayers.length > 0) {
+                        Ext.each(child.childLayers, function (layer) {
+                            config[layer.name] = layer;
+                        });
+                    }
                 }
             }
             return config;


### PR DESCRIPTION
for layers groups, we need to parse the children when generating the list of queriable layers, otherwise the layer is not found in the list and, obviously, their min/maxresolution are not available to determine if they are queriable at the current resolution.
