### PR TITLE
Take wmsResolutionHint into account

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -940,7 +940,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
             visibility: layerNode.isChecked,
             isBaseLayer: false,
             mapserverURL: layerNode.wmsUrl,
-            mapserverLayers: layerNode.wmsLayers
+            mapserverLayers: layerNode.wmsLayers,
+            queryLayers: layerNode.queryLayers
         }, this.wmtsOptions || {}));
 
         var treeNode = layerNode.node;


### PR DESCRIPTION
PR https://github.com/camptocamp/c2cgeoportal/pull/582 adds wmsResolutionHint to WMTS layers in the "theme" object. This CGXP PR uses that property to avoid making WFS/box queries for layers that are "out of range".

This PR will conflict with #447. I think we should address and merge #447 first. I can then rebase my resolution-hint branch onto the new master.
