### PR TITLE
Fix query layer search.

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -245,9 +245,10 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
             }
             return config;
         }
-        var themes = (this.themes.local || []).concat(
-            this.themes.external || []);
-        this.layersConfig = browse(themes);
+        this.layersConfig = browse(this.themes.local);
+        if (this.themes.external) {
+            this.externalLayersConfig = browse(this.themes.external);
+        }
 
         this.buildWMSControl(map);
         this.buildWFSControls(map);
@@ -255,23 +256,32 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
 
     /** private method[getQueryableWMSLayers]
      */
-    getQueryableWMSLayers: function(layers) {
+    getQueryableWMSLayers: function(layers, external, nameOnly) {
+        var layersConfig = external ? this.externalLayersConfig :
+            this.layersConfig;
         var queryLayers = [];
         // Add only queryable layer or sublayer.
         Ext.each(layers, function(queryLayer) {
-            if (queryLayer in this.layersConfig) {
-                if (this.layersConfig[queryLayer].queryable) {
-                    queryLayers.push(queryLayer);
+            if (queryLayer in layersConfig) {
+                var queryLayerConfig = layersConfig[queryLayer];
+                if (queryLayerConfig.queryable) {
+                    if (nameOnly) {
+                        queryLayers.push(queryLayerConfig.name);
+                    }
+                    else {
+                        queryLayers.push(queryLayerConfig);
+                    }
                 }
-                Ext.each(this.layersConfig[queryLayer]
-                        .childLayers, function(childLayer) {
+                Ext.each(queryLayerConfig.childLayers, function(childLayer) {
                     if (childLayer.queryable) {
-                        queryLayers.push(childLayer.name);
+                        if (nameOnly) {
+                            queryLayers.push(childLayer.name);
+                        }
+                        else {
+                            queryLayers.push(childLayer);
+                        }
                     }
                 });
-            }
-            else {
-                queryLayers.push(queryLayer);
             }
         }, this);
         return queryLayers;
@@ -374,6 +384,17 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                             }, layer.mapserverParams)
                         };
                     }
+                    else {
+                        // Create a fake WMS layer
+                        layer = {
+                            url: layer.url,
+                            projection: layer.projection,
+                            reverseAxisOrder: OpenLayers.Function.False,
+                            params: Ext.apply({}, layer.params)
+                        };
+                        layer.params.LAYERS = self.getQueryableWMSLayers(
+                            layer.params.LAYERS, layer.params.EXTERNAL, true);
+                    }
                     var services = layer.params.EXTERNAL ?
                         externalServices : internalServices;
                     var url = OpenLayers.Util.isArray(layer.url) ?
@@ -389,15 +410,11 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                 for (var url in internalServices) {
                     var wmsOptions = this.buildWMSOptions(url, services[url],
                         clickPosition, 'image/png');
-                    wmsOptions.params.QUERY_LAYERS = self.getQueryableWMSLayers(
-                        wmsOptions.params.QUERY_LAYERS);
                     OpenLayers.Request.GET(wmsOptions);
                 }
                 for (var url in externalServices) {
                     var wmsOptions = this.buildWMSOptions(url, services[url],
                         clickPosition, 'image/png');
-                    wmsOptions.params.QUERY_LAYERS = self.getQueryableWMSLayers(
-                        wmsOptions.params.QUERY_LAYERS);
                     wmsOptions.params.EXTERNAL = true;
                     OpenLayers.Request.GET(wmsOptions);
                 }
@@ -579,45 +596,42 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
         var currentRes = map.getResolution();
         Ext.each(olLayers, function(olLayer) {
             if (olLayer.getVisibility() === true) {
-                var layers = olLayer.params.LAYERS ||
-                             olLayer.queryLayers ||
-                             olLayer.mapserverLayers;
+                var external = olLayer.mapserverParams &&
+                    olLayer.mapserverParams.EXTERNAL ||
+                    olLayer.params && olLayer.params.EXTERNAL;
+                var layers;
+                if (olLayer.mapserverLayers || olLayer.queryLayers) {
+                    layers = Ext.isArray(olLayer.queryLayers) ?
+                        olLayer.queryLayers :
+                        olLayer.queryLayers || olLayer.mapserverLayers;
+                    if (!Ext.isArray(layers)) {
+                        layers = layers.split(',');
+                    }
+                }
+                else {
+                    layers = olLayer.params.LAYERS;
+                    if (!Ext.isArray(layers)) {
+                        layers = layers.split(',');
+                    }
+                    layers = this.getQueryableWMSLayers(layers, external);
+                }
                 if (!layers) {
                     return;
                 }
 
-                if (!Ext.isArray(layers)) {
-                    layers = layers.split(',');
-                }
-                layers = this.getQueryableWMSLayers(layers);
-
                 var filteredLayers = [];
                 Ext.each(layers, function(layer) {
-                    l = this.layersConfig[layer];
-                    if (l) {
-                        if (l.childLayers && l.childLayers.length > 0) {
-                            // layer is a layergroup (as per Mapserver)
-                            Ext.each(l.childLayers, function(child) {
-                                if (inRange(child, currentRes)) {
-                                    filteredLayers.push(c.name);
-                                }
-                            }, this);
-                        } else {
-                            // layer is not a layergroup
-                            if (inRange(l, currentRes)) {
-                                filteredLayers.push(layer);
-                            }
-                        }
-                    } else if (inRange(layer, currentRes)) {
-                        filteredLayers.push(layer.name || layer);
+                    if (Ext.isString(layer)) {
+                        filteredLayers.push(layer);
+                    }
+                    else if (inRange(layer, currentRes)) {
+                        filteredLayers.push(layer.name);
                     }
                 }, this);
 
                 Ext.each(filteredLayers, function(layer) {
                     var queried = false;
-                    if (olLayer.mapserverParams &&
-                            olLayer.mapserverParams.EXTERNAL ||
-                            olLayer.params && olLayer.params.EXTERNAL) {
+                    if (external) {
                         if (this.externalWFSTypes.indexOf(layer) >= 0) {
                             externalLayers.push(layer);
                             queried = true;


### PR DESCRIPTION
Now layersConfig will contains layers defined in the layer tree
(MapServer layer or group).
External Layers are stored in a deferent variable
(externalLayersConfig).
getQueryableWMSLayers return Mapserver Layer (no group) as object or
name.
getQueryableWMSLayers is not called for layer that defined
mapserverLayers or queryLayers.

Tested on Cartoriviera and on Morges
replace #447
fix #453 if we specify `queryLayers: []` on ortho layers
