### PR TITLE
implement measure popup fixed positionning, documentation to enable on-t...

### DIFF
--- a/core/src/script/CGXP/plugins/Measure.js
+++ b/core/src/script/CGXP/plugins/Measure.js
@@ -423,8 +423,8 @@ cgxp.plugins.Measure = Ext.extend(gxp.plugins.Tool, {
         }
         if (!this.controlOptions.immediate) {
             this.popup.hide();
-            this.popup.setTitle(title);
         }
+        this.popup.setTitle(title);
 
         var order = event.order,
             geom = event.geometry;


### PR DESCRIPTION
...he-fly measurement

this implement the new measurement behavior listed in the offer document from 14.06.2012 (MFUsergroup_geoportail_evolutions2013_v1.1.pdf)
#22 AMÉLIORATION DES OUTILS DE MESURES, part a) fixed positioning and b) real time calculation

I decided to use either an Ext.Window or a GeoExt.Popup depending of the positioning chosen by the user, because the GeoExt.Popup has specific styling and behavior which would have been in the way when using a fixed positioning
