### PR TITLE
Add attribute to QueryBuilder for feeding values combobox

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -164,6 +164,11 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
      *  ``Ext.LoadMask``
      */
     mask: null,
+    
+    /** private: property[storeUriProperty]
+     *  ``String``
+     */
+    storeUriProperty: "url",
 
     /** private: method[addOutput]
      *  :arg config: ``Object``
@@ -347,7 +352,7 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                     listWidth: 200
                 },
                 values: {
-                    storeUriProperty: 'url',
+                    storeUriProperty: this.storeUriProperty,
                     storeOptions: {
                         root: 'items',
                         fields: ['label', 'value']
@@ -453,8 +458,8 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                         r.set("displayName", OpenLayers.i18n(r.get("name")));
                         if (featureType in this.attributeURLs &&
                             r.get("name") in this.attributeURLs[featureType]) {
-                            r.set("url", this.attributeURLs[featureType]
-                                                           [r.get("name")]);
+                            r.set(this.storeUriProperty,
+                                  this.attributeURLs[featureType][r.get("name")]);
                         }
                     }, this);
                     this.createProtocol(store, featureType);


### PR DESCRIPTION
In the QueryBuilder panel, one may use a combobox instead of a simple text field if the selected attribute has a "url"  property. It seems not possible to add this info directly in the mapfile/layer metadata.

This PR adds the info, using a new parameter in the plugin's config. For instance:

```
        attributeURLs: {
            "areal_liegenschaften": {
                "gemeinde": "${request.static_url('<project>:static/json/gemeinde.json')}"
            }    
        }
```

The project must expose some static files or webservices that give the value to add in the comboboxes. For instance:

```
{
    items: [
        {label: 'Liestal', value: 'Liestal'},
        {label: 'Sissach', value: 'Sissach'},
        {label: 'Lausen', value: 'Lausen'}
    ]
}
```
