### PR TITLE
autoload googleearth and kml

### DIFF
--- a/core/src/script/CGXP/plugins/AddKMLFile.js
+++ b/core/src/script/CGXP/plugins/AddKMLFile.js
@@ -77,6 +77,21 @@ cgxp.plugins.AddKMLFile = Ext.extend(gxp.plugins.Tool, {
      */
     actionConfig: null,
 
+    /** api: config[googleEarthPluginId]
+     *  ``String``
+     *  A reference id to the ``GoogleEarthView`` plugin, mandatory 
+     *  if you want to auto-load that plugin when loading a kml file.
+     */
+    googleEarthPluginId: null,
+
+    /** api: config[autoloadGoogleEarth]
+     *  ``Boolean``
+     *  Enable or disable ``GoogleEarthView`` plugin auto-loading.
+     *
+     *  default to false
+     */
+    autoloadGoogleEarth: false,
+
     /** private: method[addActions]
      */
     addActions: function() {
@@ -120,14 +135,30 @@ cgxp.plugins.AddKMLFile = Ext.extend(gxp.plugins.Tool, {
                 layer.addFeatures(kmlFormat.read(kmlString));
                 map.addLayer(layer);
 
-                // Add KML file to GoogleEarthPanel
                 var googleEarthPanel = Ext.getCmp("googleearthpanel");
+                // Autoload GoogleEarthPanel
+                if (!googleEarthPanel && this.autoloadGoogleEarth) {
+                    if (!this.googleEarthPluginId) {
+                        alert('googleEarthPluginId must be defined in your cgxp_addkmlfile config.')
+                    } else {
+                        var ge = this.target.tools[this.googleEarthPluginId];
+                        ge.loadGoogleEarth();
+                        // change button state to reflect current enabled state
+                        ge.actions[0].items[0].toggle(true, true);
+                    }
+                }
+                // Add KML file to GoogleEarthPanel
                 if (googleEarthPanel) {
                     var gePlugin = googleEarthPanel.earth;
                     if (gePlugin) {
                         var kmlObject = gePlugin.parseKml(kmlString);
                         gePlugin.getFeatures().appendChild(kmlObject);
                     }
+                } 
+                // Store kmlString to load them in GoogleEarth later
+                if (this.googleEarthPluginId) {
+                    var ge = this.target.tools[this.googleEarthPluginId];
+                    ge.kmlList.push(kmlString);
                 }
 
                 form.reset();

--- a/core/src/script/CGXP/plugins/GoogleEarthView.js
+++ b/core/src/script/CGXP/plugins/GoogleEarthView.js
@@ -183,6 +183,12 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
      */
     showTreesLayer: null,
 
+    /** api: property[kmlList]
+     *  List to store kml strings to be able to load them into GoogleEarth 
+     *  when it is ready.
+     */
+    kmlList: [],
+
     /** private: property[intermediateContainer]
      *  Required intermediate container
      */
@@ -234,135 +240,155 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
             listeners: {
                 "toggle": function(button) {
                     if (button.pressed) {
-
-                        Ext.each(
-                            this.target.mapPanel.map.getControlsByClass("OpenLayers.Control.KeyboardDefaults"),
-                            function(control) {
-                                control.deactivate();
-                            });
-
-                        if (this.intermediateContainer === null) {
-                            this.intermediateContainer = this.outputTarget.add({
-                                autoDestroy: false,
-                                layout: "fit",
-                                region: "east",
-                                split: true,
-                                collapseMode: "mini"
-                            });
-                        }
-
-                        this.googleEarthPanel = new cgxp.GoogleEarthPanel({
-                            flyToSpeed: null,
-                            id: "googleearthpanel",
-                            mapPanel: this.target.mapPanel
-                        });
-
-                        this.googleEarthViewControl = new OpenLayers.Control.GoogleEarthView();
-                        var googleEarthView = this;
-                        this.pluginReadyCallback = OpenLayers.Function.bind(function(gePlugin) {
-
-                            // The gxp.GoogleEarthPanel fits the 3D view to the 2D view as closely as possible.
-                            // We want some hot tilting action, so we set our own camera position here.
-                            // This callback is called after the gxp.GoogleEarthPanel sets its camera, so ours wins.
-
-                            var extent = this.map.getExtent();
-                            var mapProjection = this.map.getProjectionObject();
-
-                            var lookAt = gePlugin.createLookAt("");
-
-                            // Place the look at point top left of the center of the map
-                            var lookAtGeometry = new OpenLayers.Geometry.Point(
-                                0.6 * extent.left   + 0.4 * extent.right,
-                                0.4 * extent.bottom + 0.6 * extent.top);
-                            lookAtGeometry.transform(mapProjection, this.geProjection);
-                            var latitude = lookAtGeometry.y;
-                            var longitude = lookAtGeometry.x;
-                            var altitude = 0;
-                            var altitudeMode = gePlugin.ALTITUDE_RELATIVE_TO_GROUND;
-
-                            // Place the camera bottom right of the center of the map
-                            var heading = -45;
-                            var tilt = 60;
-                            var cameraGeometry = new OpenLayers.Geometry.Point(
-                                0.4 * extent.left   + 0.6 * extent.right,
-                                0.6 * extent.bottom + 0.4 * extent.top);
-                            cameraGeometry.transform(mapProjection, this.geProjection);
-                            var range = OpenLayers.Spherical.computeDistanceBetween(
-                                new OpenLayers.LonLat(cameraGeometry.x, cameraGeometry.y),
-                                new OpenLayers.LonLat(lookAtGeometry.x, lookAtGeometry.y));
-
-                            lookAt.set(latitude, longitude, altitude, altitudeMode, heading, tilt, range);
-                            gePlugin.getView().setAbstractView(lookAt);
-
-                            var layerRoot = gePlugin.getLayerRoot();
-                            if (googleEarthView.showBordersLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_BORDERS, googleEarthView.showBordersLayer);
-                            }
-                            if (googleEarthView.showBuildingsLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_BUILDINGS, googleEarthView.showBuildingsLayer);
-                            }
-                            if (googleEarthView.showBuildingsLowResolutionLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_BUILDINGS_LOW_RESOLUTION, googleEarthView.showBuildingsLowResolutionLayer);
-                            }
-                            if (googleEarthView.showRoadsLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_ROADS, googleEarthView.showRoadsLayer);
-                            }
-                            if (googleEarthView.showTerrainLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_TERRAIN, googleEarthView.showTerrainLayer);
-                            }
-                            if (googleEarthView.showTreesLayer !== null) {
-                                layerRoot.enableLayerById(gePlugin.LAYER_TREES, googleEarthView.showTreesLayer);
-                            }
-
-                            this.setGEPlugin(gePlugin);
-                            this.activate();
-
-                        }, this.googleEarthViewControl);
-                        this.googleEarthPanel.on("pluginready", this.pluginReadyCallback);
-                        this.target.mapPanel.map.addControl(this.googleEarthViewControl);
-
-                        this.outputTarget.add(this.intermediateContainer);
-                        // mark as not rendered to force to render the new component.
-                        this.outputTarget.layout.rendered = false;
-
-                        this.intermediateContainer.add(this.googleEarthPanel);
-                        this.intermediateContainer.setSize(this.size, 0);
-                        this.intermediateContainer.setVisible(true);
-                        this.outputTarget.doLayout();
+                        this.loadGoogleEarth();
                     } else {
-
-                        this.googleEarthPanel.un("pluginready", this.pluginReadyCallback);
-                        this.pluginReadyCallback = null;
-
-                        this.target.mapPanel.map.removeControl(this.googleEarthViewControl);
-                        this.googleEarthViewControl.destroy();
-                        this.googleEarthViewControl = null;
-
-                        this.target.mapPanel.layers.each(function(record) {
-                            var layer = record.getLayer();
-                            if (cgxp.plugins.GoogleEarthView.isKmlLayer(layer)) {
-                                layer.destroy();
-                            }
-                        });
-
-                        this.googleEarthPanel.destroy();
-                        this.googleEarthPanel = null;
-
-                        this.intermediateContainer.setVisible(false);
-                        this.outputTarget.doLayout();
-
-                        Ext.each(
-                            this.target.mapPanel.map.getControlsByClass("OpenLayers.Control.KeyboardDefaults"),
-                            function(control) {
-                                control.activate();
-                            });
-
+                        this.unloadGoogleEarth();
                     }
                 },
                 scope: this
             }
         }, this.actionConfig);
         return cgxp.plugins.GoogleEarthView.superclass.addActions.apply(this, [button]);
+    },
+
+    /** api: method[loadGoogleEarth]
+     *  Load and open the GoogleEarth panel and initialize GoogleEarth
+     */
+    loadGoogleEarth: function() {
+        Ext.each(
+            this.target.mapPanel.map.getControlsByClass("OpenLayers.Control.KeyboardDefaults"),
+            function(control) {
+                control.deactivate();
+            });
+
+        if (this.intermediateContainer === null) {
+            this.intermediateContainer = this.outputTarget.add({
+                autoDestroy: false,
+                layout: "fit",
+                region: "east",
+                split: true,
+                collapseMode: "mini"
+            });
+        }
+
+        this.googleEarthPanel = new cgxp.GoogleEarthPanel({
+            flyToSpeed: null,
+            id: "googleearthpanel",
+            mapPanel: this.target.mapPanel
+        });
+
+        this.googleEarthViewControl = new OpenLayers.Control.GoogleEarthView();
+        var googleEarthView = this;
+        this.pluginReadyCallback = OpenLayers.Function.bind(function(gePlugin) {
+
+            // The gxp.GoogleEarthPanel fits the 3D view to the 2D view as closely as possible.
+            // We want some hot tilting action, so we set our own camera position here.
+            // This callback is called after the gxp.GoogleEarthPanel sets its camera, so ours wins.
+
+            var extent = this.map.getExtent();
+            var mapProjection = this.map.getProjectionObject();
+
+            var lookAt = gePlugin.createLookAt("");
+
+            // Place the look at point top left of the center of the map
+            var lookAtGeometry = new OpenLayers.Geometry.Point(
+                0.6 * extent.left   + 0.4 * extent.right,
+                0.4 * extent.bottom + 0.6 * extent.top);
+            lookAtGeometry.transform(mapProjection, this.geProjection);
+            var latitude = lookAtGeometry.y;
+            var longitude = lookAtGeometry.x;
+            var altitude = 0;
+            var altitudeMode = gePlugin.ALTITUDE_RELATIVE_TO_GROUND;
+
+            // Place the camera bottom right of the center of the map
+            var heading = -45;
+            var tilt = 60;
+            var cameraGeometry = new OpenLayers.Geometry.Point(
+                0.4 * extent.left   + 0.6 * extent.right,
+                0.6 * extent.bottom + 0.4 * extent.top);
+            cameraGeometry.transform(mapProjection, this.geProjection);
+            var range = OpenLayers.Spherical.computeDistanceBetween(
+                new OpenLayers.LonLat(cameraGeometry.x, cameraGeometry.y),
+                new OpenLayers.LonLat(lookAtGeometry.x, lookAtGeometry.y));
+
+            lookAt.set(latitude, longitude, altitude, altitudeMode, heading, tilt, range);
+            gePlugin.getView().setAbstractView(lookAt);
+
+            var layerRoot = gePlugin.getLayerRoot();
+            if (googleEarthView.showBordersLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_BORDERS, googleEarthView.showBordersLayer);
+            }
+            if (googleEarthView.showBuildingsLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_BUILDINGS, googleEarthView.showBuildingsLayer);
+            }
+            if (googleEarthView.showBuildingsLowResolutionLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_BUILDINGS_LOW_RESOLUTION, googleEarthView.showBuildingsLowResolutionLayer);
+            }
+            if (googleEarthView.showRoadsLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_ROADS, googleEarthView.showRoadsLayer);
+            }
+            if (googleEarthView.showTerrainLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_TERRAIN, googleEarthView.showTerrainLayer);
+            }
+            if (googleEarthView.showTreesLayer !== null) {
+                layerRoot.enableLayerById(gePlugin.LAYER_TREES, googleEarthView.showTreesLayer);
+            }
+
+            this.setGEPlugin(gePlugin);
+            this.activate();
+
+            // load kml into GE
+            var gePlugin = googleEarthView.googleEarthPanel.earth;
+            if (gePlugin) {
+                for (var i=0,l=googleEarthView.kmlList.length; i<l; i++) {
+                    var kmlObject = gePlugin.parseKml(googleEarthView.kmlList[i]);
+                    gePlugin.getFeatures().appendChild(kmlObject);
+                }
+            }
+
+        }, this.googleEarthViewControl);
+        this.googleEarthPanel.on("pluginready", this.pluginReadyCallback);
+        this.target.mapPanel.map.addControl(this.googleEarthViewControl);
+
+        this.outputTarget.add(this.intermediateContainer);
+        // mark as not rendered to force to render the new component.
+        this.outputTarget.layout.rendered = false;
+
+        this.intermediateContainer.add(this.googleEarthPanel);
+        this.intermediateContainer.setSize(this.size, 0);
+        this.intermediateContainer.setVisible(true);
+        this.outputTarget.doLayout();
+    },
+
+    /** api: method[unloadGoogleEarth]
+     *  Uninitialize GoogleEarth and unload and close the GoogleEarth panel
+     */
+    unloadGoogleEarth: function() {
+        this.googleEarthPanel.un("pluginready", this.pluginReadyCallback);
+        this.pluginReadyCallback = null;
+
+        this.target.mapPanel.map.removeControl(this.googleEarthViewControl);
+        this.googleEarthViewControl.destroy();
+        this.googleEarthViewControl = null;
+
+        this.target.mapPanel.layers.each(function(record) {
+            var layer = record.getLayer();
+            if (cgxp.plugins.GoogleEarthView.isKmlLayer(layer)) {
+                layer.destroy();
+            }
+        });
+
+        this.googleEarthPanel.destroy();
+        this.googleEarthPanel = null;
+
+        this.intermediateContainer.setVisible(false);
+        this.outputTarget.doLayout();
+
+        Ext.each(
+            this.target.mapPanel.map.getControlsByClass("OpenLayers.Control.KeyboardDefaults"),
+            function(control) {
+                control.activate();
+            });
     }
 });
 


### PR DESCRIPTION
this is a response to #509 

now, when loading a new kml, if GoogleEarth is not running/initialized, the kml string is stored, then, when GoogleEarth is activated, the kml string list is parsed and the kml loaded into GoogleEarth.

I have also added an option to autoload GoogleEarth when a kml is loaded.

I have moved the GoogleEarth load and unload code out of the button/toggle action, to be able to call GoogleEarth load code from the addKml plugin.

can be tested there http://preprod.cartoriviera.ch/och/wsgi/
