### PR TITLE
Bug - layertree

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -317,6 +317,9 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     this.addShowIn3DAction(item, nodeConfig);
                     this.addLegend(item, nodeConfig, level);
                     this.addScaleAction(item, nodeConfig);
+                    // FIXME We create a cgxp_layerparam node for a WMTS layer.
+                    // That doesn't make sense, but cgxp_layerparam does work
+                    // for us.
                     Ext.apply(nodeConfig, {
                         nodeType: 'cgxp_layerparam',
                         leaf: true,


### PR DESCRIPTION
I've updated CGXP on SITN and I have a bug since then.

Firebug tells me that `styles is undefined` on line 337 of https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/widgets/tree/LayerTree.js

This line was inserted by commit https://github.com/caatmptocamp/cgxp/commit/622e2dc330ef1a69aa40fd7720f3f909093fa0a6

Could somebody check what's wrong and eventually propose a patch?
