### PR TITLE
Make sure the legend panel uses a GLG when a layer has no static icon

### DIFF
--- a/core/src/script/CGXP/widgets/WMSLegend.js
+++ b/core/src/script/CGXP/widgets/WMSLegend.js
@@ -40,6 +40,12 @@ cgxp.WMSLegend = Ext.extend(GeoExt.WMSLegend, {
      */
     updateDelay: 0,
 
+    /** api: config[defaultStyleIsFirst]
+     *  ``Boolean``
+     *  If no style can be found for a layer, use a GetLegendGraphic request.
+     */
+    defaultStyleIsFirst: false,
+
     /** private: method[initComponent]
      *  Initialized the WMS legend.
      */


### PR DESCRIPTION
As for now, if a layer has a static icon set in the admin interface, all the other layers contained in the same layergroup will incorrectly been attributed the same icon in the legend panel if they don't have themselves a static icon. The correct behaviour would be to make a GetLegendGraphic request for those layers.

The current PR deactivates a default behaviour in GeoExt that uses the default styles provided with a given OL layer when no specific style can be found for a given legend node.
See https://github.com/geoext/geoext/blob/master/lib/GeoExt/widgets/WMSLegend.js#L143
