### PR TITLE
fixed js error in IE8: ContextualData's ContextPopup control was added t...

### DIFF
--- a/core/src/script/CGXP/plugins/ContextualData.js
+++ b/core/src/script/CGXP/plugins/ContextualData.js
@@ -750,7 +750,6 @@ cgxp.plugins.ContextualData.ContextPopup = OpenLayers.Class(cgxp.plugins.Context
                 return false; // For IE browsers.
             }
         };
-        this.map.addControl(this);
         this.activate();
     },
 

--- a/core/src/script/CGXP/plugins/Profile.js
+++ b/core/src/script/CGXP/plugins/Profile.js
@@ -694,8 +694,7 @@ cgxp.plugins.Profile.Control = OpenLayers.Class(OpenLayers.Control.DrawFeature, 
     },
 
     destroy: function() {
-        this.layer.destroyFeatures();
-        this.layer.map.removeLayer(this.layer);
+        this.deactivate();
         this.layer.destroy();
         this.hoverHandler.destroy();
         OpenLayers.Control.DrawFeature.prototype.destroy.call(this);


### PR DESCRIPTION
...wice, Profile's layer was destroyed even if it was not created beforhand.
These caused some js error on page unload with IE8 when these plugins were enabled.
