### PR TITLE
redlining example: small typo in ptype

### DIFF
--- a/core/src/script/CGXP/plugins/Redlining.js
+++ b/core/src/script/CGXP/plugins/Redlining.js
@@ -44,7 +44,7 @@ Ext.namespace("cgxp.plugins");
  *      new gxp.Viewer({
  *          ...
  *          tools: [{
- *              ptype: 'cgxp_redligning',
+ *              ptype: 'cgxp_redlining',
  *              actionTarget: 'center.tbar',
  *              toggleGroup: 'maptools',
  *              stateId: 'rl', // to save the drawing in the permalink


### PR DESCRIPTION
just a small typo correction
