### PR TITLE
add support for encoding and file extension for csv export

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesGrid.js
+++ b/core/src/script/CGXP/plugins/FeaturesGrid.js
@@ -252,6 +252,18 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
      */
     highlightStyle: null,
 
+    /** api: config[csvExtension]
+     *  ``String``  The extension to use for the exported csv file.
+     *  Default is 'csv'.
+     */
+    csvExtension: 'csv',
+
+    /** api: config[csvEncoding]
+     *  ``String``  The encoding to use for the exported csv file.
+     *  Default is 'UTF-8'.
+     */
+    csvEncoding: 'UTF-8',
+
     /** private: property[selectAll]
      */
 
@@ -319,7 +331,9 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
                 method: 'POST',
                 params: {
                     name: this.currentGrid.title,
-                    csv: csv.join('\n')
+                    csv: csv.join('\n'),
+                    csv_extension: this.csvExtension,
+                    csv_encoding: this.csvEncoding
                 },
                 form: this.dummyForm,
                 isUpload: true


### PR DESCRIPTION
this pr solver the issue https://github.com/camptocamp/cgxp/issues/521

it implement the possibility to specify the encoding and the file extension for the csv export

utf8 and .csv have been tested ok with the following programs:
Excel 2007
Excel 2010
LibreOffice 4.0.4.2
LibreOffice 3.5.7.2

not ok with:
Excel 2002 (no utf8 support at all)
OpenOffice 3.3.0 (utf8 not recognized automatically, but can chose the encoding on start)
