### PR TITLE
Remove trailing # in logoutURL

### DIFF
--- a/core/src/script/CGXP/plugins/Login.js
+++ b/core/src/script/CGXP/plugins/Login.js
@@ -213,7 +213,9 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
                     Ext.Ajax.request({
                         url: this.logoutURL,
                         success: function() {
-                            window.location.href = window.location.href;
+                            url = window.location.href;
+                            url = url.replace(/#.*$/, '');
+                            window.location.href = url;
                         }
                     });
                 },


### PR DESCRIPTION
A trailing # in the URL prevents the application from reloading after logging out.
Fix #563 
