### PR TITLE
fix splitbar problem with GoogleEarthView / StreetView

### DIFF
--- a/core/src/script/CGXP/patches/PatchExt.js
+++ b/core/src/script/CGXP/patches/PatchExt.js
@@ -1,0 +1,58 @@
+/*
+    Solves a problem with plugins GoogleEarth and StreetView causing a 
+    duplicated splitbar, dued to the forced "rendered = false". The latter 
+    configuration is required otherwise the panels contents are not rendered 
+    correctly when the panels are re-opened.
+*/
+Ext.layout.BorderLayout.SplitRegion.override({
+  
+    render : function(ct, p){
+
+        Ext.layout.BorderLayout.SplitRegion.superclass.render.call(this, ct, p);
+
+        var ps = this.position;
+        
+        // start override
+        var elId = this.panel.id + '-xsplit';
+        var el = Ext.get(elId);
+        if (!el)  {
+            this.splitEl = ct.createChild({
+                cls: "x-layout-split x-layout-split-"+ps, html: "&#160;",
+                id: elId
+            });
+        } else {
+            this.splitEl = el;
+        }
+        // end override
+
+        if(this.collapseMode == 'mini'){
+            this.miniSplitEl = this.splitEl.createChild({
+                cls: "x-layout-mini x-layout-mini-"+ps, html: "&#160;"
+            });
+            this.miniSplitEl.addClassOnOver('x-layout-mini-over');
+            this.miniSplitEl.on('click', this.onCollapseClick, this, {stopEvent:true});
+        }
+
+        var s = this.splitSettings[ps];
+
+        this.split = new Ext.SplitBar(this.splitEl.dom, p.el, s.orientation);
+        this.split.tickSize = this.tickSize;
+        this.split.placement = s.placement;
+        this.split.getMaximumSize = this[s.maxFn].createDelegate(this);
+        this.split.minSize = this.minSize || this[s.minProp];
+        this.split.on("beforeapply", this.onSplitMove, this);
+        this.split.useShim = this.useShim === true;
+        this.maxSize = this.maxSize || this[s.maxProp];
+
+        if(p.hidden){
+            this.splitEl.hide();
+        }
+
+        if(this.useSplitTips){
+            this.splitEl.dom.title = this.collapsible ? this.collapsibleSplitTip : this.splitTip;
+        }
+        if(this.collapsible){
+            this.splitEl.on("dblclick", this.onCollapseClick,  this);
+        }
+    }
+});

--- a/core/src/script/CGXP/plugins/GoogleEarthView.js
+++ b/core/src/script/CGXP/plugins/GoogleEarthView.js
@@ -17,6 +17,7 @@
 
 /**
  * @requires plugins/Tool.js
+ * @requires CGXP/patches/PatchExt.js
  * @include OpenLayers/Control/GoogleEarthView.js
  * @include plugins/GoogleEarth.js
  * @include CGXP/widgets/GoogleEarthPanel.js
@@ -351,12 +352,16 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
         this.target.mapPanel.map.addControl(this.googleEarthViewControl);
 
         this.outputTarget.add(this.intermediateContainer);
-        // mark as not rendered to force to render the new component.
-        this.outputTarget.layout.rendered = false;
-
+        
         this.intermediateContainer.add(this.googleEarthPanel);
         this.intermediateContainer.setSize(this.size, 0);
         this.intermediateContainer.setVisible(true);
+
+        /* Marked as not rendered in order to force the rendering of the component.
+           Otherwise the panel is not rendered correctly when switching between 
+           GoogleEarth and StreetView. */
+        this.outputTarget.layout.rendered = false;
+
         this.outputTarget.doLayout();
     },
 
@@ -364,6 +369,13 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
      *  Uninitialize GoogleEarth and unload and close the GoogleEarth panel
      */
     unloadGoogleEarth: function() {
+        /* solve problem with Ext duplicating the splitbar when doLayout is called
+           because of the rendered = false above */
+        if (this.outputTarget.layout.east && this.outputTarget.layout.east.splitEl) {
+            this.outputTarget.layout.east.splitEl.remove();
+            this.outputTarget.layout.east.splitEl = null;
+        }
+        
         this.googleEarthPanel.un("pluginready", this.pluginReadyCallback);
         this.pluginReadyCallback = null;
 

--- a/core/src/script/CGXP/plugins/StreetView.js
+++ b/core/src/script/CGXP/plugins/StreetView.js
@@ -17,6 +17,7 @@
 
 /**
  * @requires plugins/Tool.js
+ * @requires CGXP/patches/PatchExt.js
  * @include ux/widgets/StreetViewPanel.js
  */
 
@@ -130,11 +131,15 @@ cgxp.plugins.StreetView = Ext.extend(gxp.plugins.Tool, {
                             this.panel.clickControl.activate();
                         }
                         this.outputTarget.add(this.panel);
-                        // mark as not rendered to force to render the new component.
-                        this.outputTarget.layout.rendered = false;
 
                         this.panel.setSize(this.size, 0);
                         this.panel.setVisible(true);
+
+                        /* Marked as not rendered in order to force the rendering of the component.
+                           Otherwise the panel is not rendered correctly when switching between 
+                           GoogleEarth and StreetView. */
+                        this.outputTarget.layout.rendered = false;
+
                         this.panel.doLayout();
 
                         (function() {
@@ -142,6 +147,13 @@ cgxp.plugins.StreetView = Ext.extend(gxp.plugins.Tool, {
                         }).defer(100, this);
                     }
                     else {
+                        /* solve problem with Ext duplicating the splitbar when doLayout is called
+                           because of the rendered = false above */
+                        if (this.outputTarget.layout.east && this.outputTarget.layout.east.splitEl) {
+                            this.outputTarget.layout.east.splitEl.remove();
+                            this.outputTarget.layout.east.splitEl = null;
+                        }
+
                         this.panel.panorama.navigationToolLayer.setVisibility(false);
                         this.panel.panorama.navigationLinkLayer.setVisibility(false);
                         this.panel.clickControl.deactivate();


### PR DESCRIPTION
when doLayout is called on the closed GoogleEarthView panel, somehow the main layout is set a not rendered and Ext create a new splitbar when the panel is re-opened, this happen everytime we close and open the GoogleEarthView panel

fix https://github.com/camptocamp/cgxp/issues/426
