### PR TITLE
Reset the wait cursor when no layers are queryable.

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -445,6 +445,8 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                     self.events.fireEvent('queryresults', {
                         features: []
                     });
+                    // Reset the cursor.
+                    OpenLayers.Element.removeClass(this.map.viewPortDiv, "olCursorWait");
                 }
 
                 if (self.autoDeactivate && self.action) {


### PR DESCRIPTION
Fix #573 
