### PR TITLE
Undefined layers variable in plugin FeaturesResult

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesResult.js
+++ b/core/src/script/CGXP/plugins/FeaturesResult.js
@@ -103,11 +103,11 @@ cgxp.plugins.FeaturesResult = Ext.extend(gxp.plugins.Tool, {
                 if (Ext.isArray(layer.queryLayers)) {
                     Ext.each(layer.queryLayers, function(queryLayer) {
                         if (queryLayer.name && queryLayer.identifierAttribute) {
-                            layers[queryLayer.name] = queryLayer;
+                            this.layers[queryLayer.name] = queryLayer;
                         }
-                    });
+                    }, this);
                 }
-            });
+            }, this);
         }, this);
     },
 


### PR DESCRIPTION
There is no "layers" variable in this file but @sbrunner renamed "layers" to "this.layers" in c993f2b0d7ad. Perhaps a missed one?
(not tested!)
