### PR TITLE
adapte print panel content to the tool window size

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -288,7 +288,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                 height: 350,
                 closeAction: 'hide',
                 autoScroll: true,
-                cls: 'toolwindow'
+                cls: 'toolwindow printpanel'
             });
 
             printWin.on({

--- a/core/src/theme/all.css
+++ b/core/src/theme/all.css
@@ -589,3 +589,17 @@ div.x-panel .olControlZoom a:hover {
 .login-failure-msg {
     color: red;
 }
+
+/* Print panel */
+.printpanel .x-form-label-top .x-form-element {
+     padding-top: 0;
+}
+.printpanel .x-form-label-top .x-form-item  {
+    padding-bottom: 2px;
+} 
+.printpanel .x-form-item {
+    margin-bottom: 0;
+}
+.printpanel textarea {
+    min-height: 50px;
+}


### PR DESCRIPTION
so the rotation field isnt hidden or cut at the bottom
this fix #488 
