### PR TITLE
Fixes wrong dimension of Time Slider in IE10

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -732,6 +732,9 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                                 target: cmp.el,
                                 html: tooltip
                             });
+                            cmp.ownerCt.doLayout.defer(
+                                1, cmp.ownerCt, [true, true]
+                            );
                         }
                     }
                 },


### PR DESCRIPTION
By forcing a deferred doLayout on its parent component.

Fixes #687
