### PR TITLE
Make featuresgrid content selectable

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesGrid.js
+++ b/core/src/script/CGXP/plugins/FeaturesGrid.js
@@ -633,7 +633,15 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
                         viewConfig: {
                             // we add an horizontal scroll bar in case
                             // there are too many attributes to display:
-                            forceFit: (columns.length < 9)
+                            forceFit: (columns.length < 9),
+                            templates: {
+                                // The cell template is overridden to enable selecting cell's content.
+                                cell: new Ext.Template(
+                                    '<td class="x-grid3-col x-grid3-cell x-grid3-td-{id} x-selectable {css}" style="{style}" tabIndex="0" {cellAttr}>',
+                                    '<div class="x-grid3-cell-inner x-grid3-col-{id}" {attr}>{value}</div>',
+                                    '</td>'
+                                )
+                            }
                         },
                         colModel: new Ext.grid.ColumnModel({
                             defaults: {

--- a/core/src/theme/all.css
+++ b/core/src/theme/all.css
@@ -434,6 +434,14 @@ div.legend .x-form-item {
     font-size: 12px;
 }
 
+.x-selectable, .x-selectable * {
+    user-select: text;
+    -moz-user-select: text;
+    -khtml-user-select: text;
+    -webkit-user-select: text;
+    -ms-user-select: text;
+}
+
 /* cgxp featureswindow */
 .x-grid3-row-body table.detail th {
     font-weight: bold;


### PR DESCRIPTION
For some reason the default behaviour of ExtJS' Grids is to disable cell content selecting. This PR reenables it so that users may copy-paste those content.

Taken from http://ahlearns.wordpress.com/2011/10/27/ext-js-make-grid-text-selectable/ itself refering to http://www.sencha.com/learn/grid-faq/

Works with IE7 to 11, FF, Chrome and Safari.
