### PR TITLE
Incorrect indentation in WFSPermalink doc

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -97,8 +97,8 @@ cgxp.plugins.WFSPermalink = Ext.extend(gxp.plugins.Tool, {
 
     /** api: config[stateId]
      *  ``String``
-     * Prefix of the permalink parameters. Default is "wfs".
-     * Optional.
+     *  Prefix of the permalink parameters. Default is "wfs".
+     *  Optional.
      */
     stateId: 'wfs',
 


### PR DESCRIPTION
which results in truncated words in the plugin's doc. See "stateId" doc at http://docs.camptocamp.net/cgxp/1.4/lib/plugins/WFSPermalink.html#config-options
