### PR TITLE
Add panelOptions to theme selector plugin

### DIFF
--- a/core/src/script/CGXP/plugins/ThemeSelector.js
+++ b/core/src/script/CGXP/plugins/ThemeSelector.js
@@ -129,7 +129,7 @@ cgxp.plugins.ThemeSelector = Ext.extend(gxp.plugins.Tool, {
                 store: externalStore
             }, tabconfig));
 
-            themepanel = new Ext.TabPanel({
+            themepanel = new Ext.TabPanel(Ext.apply({
                 width: 560,
                 activeTab: 0,
                 plain: true,
@@ -142,15 +142,14 @@ cgxp.plugins.ThemeSelector = Ext.extend(gxp.plugins.Tool, {
                         cmp.ownerCt.doLayout();
                     }
                 }
-            });
+            }, this.panelOptions));
         } else {
+            Ext.apply(tabconfig,  this.panelOptions);
             themepanel = new Ext.DataView(Ext.apply({
                 width: 560,
                 store: localStore
             }, tabconfig));
         }
-
-        Ext.apply(themepanel, this.panelOptions);
 
         config = Ext.apply({
             xtype: "button",


### PR DESCRIPTION
Title says it all.

This PR supersedes #724. It adds a `panelOptions` object to the configuration parameters of the theme selector plugin, which enables to change the panel properties.

Thanks a lot @sbrunner for your wise advises.

Please review
