### PR TITLE
WFS: get total number of features when maxFeatures is hit

### DIFF
--- a/core/src/script/CGXP/locale/de.js
+++ b/core/src/script/CGXP/locale/de.js
@@ -60,7 +60,9 @@ GeoExt.Lang.add("de", {
         resultText: "Resultat",
         resultsText: "Resultate",
         suggestionText: "Tipp",
-        noLayerSelectedMessage: "Keine Ebene ausgewählt"
+        noLayerSelectedMessage: "Keine Ebene ausgewählt",
+        totalNbOfFeaturesText: "Total Anzahl Resultate: ",
+        countingText: "(lädt...)"
     },
 
     "cgxp.plugins.FeaturesWindow.prototype": {

--- a/core/src/script/CGXP/locale/fr.js
+++ b/core/src/script/CGXP/locale/fr.js
@@ -64,7 +64,9 @@ GeoExt.Lang.add("fr", {
         resultText: "Résultat",
         resultsText: "Résultats",
         suggestionText: "Suggestion",
-        noLayerSelectedMessage: "Pas de couche sélectionnée"
+        noLayerSelectedMessage: "Pas de couche sélectionnée",
+        totalNbOfFeaturesText: "Nombre total de résultats&nbsp;: ",
+        countingText: "(en cours de calcul...)"
     },
 
     "cgxp.plugins.FeaturesWindow.prototype": {

--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -84,10 +84,10 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
     options: null,
 
     /** api: config[maxFeatures]
-     *  ``Int``
-     *  Limit of features returned by mapserver
+     *  ``Integer``
+     *  Limit of features returned by mapserver. Default is 200.
      */
-    maxFeatures: null,
+    maxFeatures: 200,
 
     /** api: config[mapserverproxyURL]
      *  ``String``
@@ -286,10 +286,7 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
         this.panel.get(1).deactivateControls();
 
         this.protocol.read({
-            // don't work with actual version of mapserver, the proxy will limit to 200
-            // it is intended to be reactivated this once mapserver is fixed
-            // features to protect the browser.
-            // maxFeatures: this.maxFeatures || 100,
+            maxFeatures: this.maxFeatures,
             filter: filter,
             callback: function(response) {
                 btn.setIconClass(btn.initialConfig.iconCls);
@@ -299,9 +296,28 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                 }
                 if (response.features && response.features.length) {
                     var fs = response, l = fs.features.length;
+                    fs.maxFeatures = this.maxFeatures;
                     // required by ResultsPanel:
                     while(l--) {
                         fs.features[l].type = this.protocol.featureType;
+                    }
+                    if (fs.features.length == this.maxFeatures) {
+                        // if the max number of allowed features is hit,
+                        // send an additional request to get the total number
+                        // of features matching the filter.
+                        this.protocol.read({
+                            filter: filter,
+                            readOptions: {output: "object"},
+                            resultType: "hits",
+                            maxFeatures: null,
+                            callback: function(response) {
+                                var infos = {
+                                    numberOfFeatures: response.numberOfFeatures,
+                                };
+                                this.events.fireEvent("queryinfos", infos);
+                            },
+                            scope: this
+                        });
                     }
                     this.events.fireEvent("queryresults", fs);
                 } else {
@@ -453,7 +469,7 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                 "TYPENAME": featureType,
                 "REQUEST": "DescribeFeatureType",
                 "SERVICE": "WFS",
-                "VERSION": "1.0.0"
+                "VERSION": "1.1.0"
             },
             listeners: {
                 "load": function() {


### PR DESCRIPTION
When a WFS filter (plugins GetFeature and QueryBuilder) returns too many results (nb > maxFeatures), the list of features is truncated to the first <maxFeatures> results.

With this PR, when the max number of features is reached, an additional WFS GetFeature request with `resultType="hits"` is triggered to get the actual number of features matching the filter (requires WFS 1.1.0). The result is then displayed in the bottom toolbar of the FeaturesGrid (FeaturesWindow does not displayed the number of features).
