### PR TITLE
Remove trailing commas - IE8

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -551,7 +551,7 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                         maxFeatures: null,
                         callback: function(response) {
                             var infos = {
-                                numberOfFeatures: response.numberOfFeatures,
+                                numberOfFeatures: response.numberOfFeatures
                             };
                             this.events.fireEvent("queryinfos", infos);
                         },

--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -312,7 +312,7 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                             maxFeatures: null,
                             callback: function(response) {
                                 var infos = {
-                                    numberOfFeatures: response.numberOfFeatures,
+                                    numberOfFeatures: response.numberOfFeatures
                                 };
                                 this.events.fireEvent("queryinfos", infos);
                             },


### PR DESCRIPTION
Commit https://github.com/camptocamp/cgxp/commit/176d94dffe2b8be075bbedc86a942980829d9c94 broke the IE8 compatibility.

This PR removes two trailing commas which break this.
