### PR TITLE
IE8 compatibility is broken - comma

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -410,7 +410,7 @@ cgxp.plugins.WFSPermalink = Ext.extend(gxp.plugins.Tool, {
                     maxFeatures: null,
                     callback: function(response) {
                         var infos = { 
-                            numberOfFeatures: response.numberOfFeatures,
+                            numberOfFeatures: response.numberOfFeatures
                         };  
                         this.events.fireEvent("queryinfos", infos);
                     },  


### PR DESCRIPTION
Same issue as PR #730, https://github.com/camptocamp/cgxp/commit/741b8972006bcce2f5a0a69a65e0e5a44b4ab834 broke the IE8 compatibility.

My 1.4 branch was not enough up-to-date to also get this one with PR #730, sorry...
