### PR TITLE
Add a raster layer parameter (array) to contextual data plugin

### DIFF
--- a/core/src/script/CGXP/plugins/ContextualData.js
+++ b/core/src/script/CGXP/plugins/ContextualData.js
@@ -369,7 +369,7 @@ cgxp.plugins.ContextualData.Control = OpenLayers.Class(OpenLayers.Control, {
         };
 
         if (this.rasterLayers) {
-            params['layers'] = this.rasterLayers.join(',');
+            params.layers = this.rasterLayers.join(',');
         }
 
         Ext.Ajax.request({


### PR DESCRIPTION
This PR enables to specify which raster layers the contextual plugin should query (by default all).

SITN needs this, because we have defined more raster layers for other purposes (raster statistics, see https://github.com/camptocamp/sitn_c2cgeoportal/pull/592), but we do not want these new rasters to be queried by the contextual data plugin (for performance issues...)

See also https://github.com/camptocamp/sitn_c2cgeoportal/issues/590 for even more explanations.

Please review
