### PR TITLE
Missing comma in GetFeature.js

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -556,7 +556,7 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
         var listeners = {
             featuresselected: function(e) {
                 this.events.fireEvent('queryresults', {
-                    features: this.filterFeatures(e.features)
+                    features: this.filterFeatures(e.features),
                     maxFeatures: this.maxFeatures
                 });
                 if (e.features.length == this.maxFeatures) {


### PR DESCRIPTION
I think that commit https://github.com/camptocamp/cgxp/commit/f4ef1746f03bc71feb4a10cf935fd58de5098e08 broke the code of this plugin.

There is a comma missing...

Please review.
