### PR TITLE
GetFeature: don't activate controls by default when an action is available

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -205,7 +205,9 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
     /** private: method[activate]
      */
     activate: function() {
-        if (!this.active) {
+        // Click control is automatically activated
+        // only if the tool has no action.
+        if (this.active === false && !this.actionTarget) {
             this.clickWMSControl.activate();
         }
         return cgxp.plugins.GetFeature.superclass.activate.call(this);
@@ -214,7 +216,7 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
     /** private: method[deactivate]
      */
     deactivate: function() {
-        if (this.active) {
+        if (this.active === true) {
             this.clickWMSControl.deactivate();
         }
         return cgxp.plugins.GetFeature.superclass.deactivate.call(this);
@@ -615,29 +617,37 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                 box: true,
                 click: false,
                 single: false,
-                eventListeners: listeners,
+                eventListeners: Ext.apply(listeners, {
+                    activate: function() {
+                        this.clickWMSControl.activate();
+                    },
+                    deactivate: function() {
+                        this.clickWMSControl.deactivate();
+                    }
+                }),
                 request: request
             });
             // don't convert pixel to box, let the WFS GetFeature to query
             this.toolWFSControl.click = true;
             map.addControl(this.toolWFSControl);
+        } else {
+            this.ctrlWFSControl = new OpenLayers.Control.GetFeature({
+                target: this.target,
+                box: true,
+                click: false,
+                single: false,
+                handlerOptions: {
+                    box: {
+                        keyMask: Ext.isMac ? OpenLayers.Handler.MOD_META :
+                            OpenLayers.Handler.MOD_CTRL
+                    }
+                },
+                autoActivate: true,
+                eventListeners: listeners,
+                request: request
+            });
+            map.addControl(this.ctrlWFSControl);
         }
-        this.ctrlWFSControl = new OpenLayers.Control.GetFeature({
-            target: this.target,
-            box: true,
-            click: false,
-            single: false,
-            handlerOptions: {
-                box: {
-                    keyMask: Ext.isMac ? OpenLayers.Handler.MOD_META :
-                        OpenLayers.Handler.MOD_CTRL
-                }
-            },
-            autoActivate: true,
-            eventListeners: listeners,
-            request: request
-        });
-        map.addControl(this.ctrlWFSControl);
     },
 
     /** private: method[getLayers]


### PR DESCRIPTION
As for now, with the GetFeature plugin, the "click" (WMS GetFeatureInfo) and "ctrl" (drag-drop while pushing the Ctrl key) controls are always activated, even though an action button is available in the toolbar and toggled off.

This does not really make sense => the controls should be active only when the button is ON. In addition it may conflicts with other tools that might be activated by default.

This PR then suggests to activate/deactivate the click and ctrl controls when the  getfeature action is toggle on/off (ie. when the "toolWFS" control - linked to the action - is activated/deactivated).

Since the "toolWFS" control behaves the same way than the "ctrl" control (drag-drop), the latter is useless when the action is available => in the PR we add the control only when the "toolWFS" control is not available (no button).

The changes have been sucessfully tested when:
- no actionTarget (no button) is set
- an actionTarget is provided and the "autoDeactivate" option is on (controls are deactivated after each query)
- an actionTarget is provided and the "autoDeactivate" option is off (controls remain active after each query)
