### PR TITLE
Wrong folder - buildout fails because jstool can't find a file

### DIFF
--- a/core/src/script/CGXP/plugins/WFSPermalink.js
+++ b/core/src/script/CGXP/plugins/WFSPermalink.js
@@ -17,7 +17,7 @@
 
 /*
  * @requires plugins/Tool.js
- * @include patches/gml.js
+ * @include CGXP/patches/gml.js
  * @include OpenLayers/Control/GetFeature.js
  * @include OpenLayers/Protocol/WFS/v1_1_0.js
  * @include OpenLayers/Filter/Comparison.js


### PR DESCRIPTION
I think that PR #756 was incomplete.

Without this correction, it is impossible to build the js files using version 1.4.4

Please review

(I made a PR to branch 1.4. As I'm using the master branch, if you could merge 1.4 into master it would be great...)
