### PR TITLE
Constrain window header

### DIFF
--- a/core/src/script/CGXP/tools/tools.js
+++ b/core/src/script/CGXP/tools/tools.js
@@ -46,6 +46,7 @@ cgxp.tools.openWindow = function(content, title, width, height) {
         title: title,
         resizable: true,
         layout:'fit',
+        constrainHeader: true,
         modal: false,
         width: width+15,
         height: height,


### PR DESCRIPTION
If the browser's window size is small, then when opening an Ext window, the window header might be behind the browser top toolbars (URL field, menu and so on). Then the user cannot anymore move or close the CGXP window.

This PR suggests to add a header constrain to the Ext window in order for it to always be visible:
![snap](https://cloud.githubusercontent.com/assets/1681332/3267430/74f8747e-f2cc-11e3-8076-6fb9ec7902ad.png)

As shown in the image, the window cannot be panned outside of the browser's top left border.

Hope you agree :grin: 
