### PR TITLE
Typo in tooltip config of GoogleEarth plugin

### DIFF
--- a/core/src/script/CGXP/plugins/GoogleEarthView.js
+++ b/core/src/script/CGXP/plugins/GoogleEarthView.js
@@ -236,7 +236,7 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
             enableToggle: true,
             toggleGroup: this.toggleGroup,
             iconCls: "cgxp-icon-googleearthview",
-            toottip: this.tooltipText,
+            tooltip: this.tooltipText,
             menuText: this.menuText,
             listeners: {
                 "toggle": function(button) {


### PR DESCRIPTION
By the way I see that this plugin uses "menuText" as many other CGXP plugins.
Why don't we also use "buttonText" that would be interesting to add a default button text instead of explicitly adding

```
actionConfig: {
    text: "foobar"
}
```

as in GMF demo:
https://github.com/camptocamp/demo_geomapfish/blob/master/demo/templates/viewer.js#L326
?
