### PR TITLE
re-enable modifyControl on cancel cancelation

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -577,6 +577,8 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                             } else {
                                 // we need to reset the cursor manually
                                 OpenLayers.Element.removeClass(self.map.viewPortDiv, "olCursorWait");
+                                self.editorGrid.modifyControl.activate();
+                                self.editorGrid.modifyControl.selectFeature(self.editorGrid.store.feature);
                             }
                         },
                         scope: this


### PR DESCRIPTION
fix #716
reactivate the modifyControl on cancel cancelation so the user can continue editing the feature
