### PR TITLE
Handling of "maxfeatures limit reached" after a GetFeature request

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesGrid.js
+++ b/core/src/script/CGXP/plugins/FeaturesGrid.js
@@ -237,7 +237,7 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
     /** api: config[maxFeaturesText]
      *  ``String`` Text for the "reached max number of features" label (i18n).
      */
-    maxFeaturesText: "Maximum of results",
+    maxFeaturesText: "The maximum number of results is reached",
     /** api: config[resultText]
      *  ``String`` Text for the "number of result" label (singular) (i18n).
      */
@@ -300,6 +300,17 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
      *  ``Integer`` Counter of features.
      */
     numberOfFeatures: 0,
+
+    /** private: attribute[numberOfReturnedFeatures]
+     *  ``Integer`` Counter of features actually returned by the query.
+     */
+    numberOfReturnedFeatures: 0,
+
+    /** private: attribute[enableTotalHits]
+     *  ``Boolean`` Tells if an additional WFS request is done to get the total
+     *  number of hits when maxFeatures limit is reached.
+     */
+    enableTotalHits: false,
 
     /** private: method[init]
      */
@@ -482,9 +493,7 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
         }
         var count = this.currentGrid.getStore().getCount();
         var resultText = (count>1) ? this.resultsText : this.resultText;
-        return (count == this.maxFeatures) ?
-                this.maxFeaturesText + '(' + this.maxFeatures + ')' :
-                count + " " + resultText;
+        return count + " " + resultText;
     },
 
     /** private: method[showFeature]
@@ -552,6 +561,8 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
 
             // reset counter when new query is triggered
             this.numberOfFeatures = 0;
+            this.numberOfReturnedFeatures = 0;
+            this.enableTotalHits = false;
 
             /* this is important, if the grid are not cleared and created a new,
                the event viewready is not triggered and we fall on an ext bug
@@ -590,16 +601,23 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
         this.events.on('queryinfos', function(infos) {
             if ('numberOfFeatures' in infos) {
                 this.numberOfFeatures += infos.numberOfFeatures;
-                this.setMessage(
-                    this.totalNbOfFeaturesText + this.numberOfFeatures
-                );
+                var msg = '';
+                if (this.numberOfReturnedFeatures == this.maxFeatures) {
+                    msg += this.maxFeaturesText + ' (' + this.maxFeatures + ') - '; 
+                }
+                msg += this.totalNbOfFeaturesText + this.numberOfFeatures;
+                this.setMessage(msg);
             }
         }, this);
 
         this.events.on('queryresults', function(queryResult, selectAll) {
             features = queryResult.features;
+            this.numberOfReturnedFeatures = features.length;
             if ('maxFeatures' in queryResult) {
                 this.maxFeatures = queryResult.maxFeatures;
+            }
+            if ('enableTotalHits' in queryResult) {
+                this.enableTotalHits = queryResult.enableTotalHits;
             }
             this.selectAll = selectAll;
 
@@ -761,8 +779,12 @@ cgxp.plugins.FeaturesGrid = Ext.extend(cgxp.plugins.FeaturesResult, {
 
             if (queryResult.message && this.vectorLayer.features.length > 0) {
                 this.setMessage(queryResult.message);
-            } else if (queryResult.features.length == this.maxFeatures) {
-                this.setMessage(this.totalNbOfFeaturesText + this.countingText);
+            } else if (this.numberOfReturnedFeatures == this.maxFeatures) {
+                if (this.enableTotalHits) {
+                    this.setMessage(this.totalNbOfFeaturesText + this.countingText);
+                } else {
+                    this.setMessage(this.maxFeaturesText + ' (' + this.maxFeatures + ')');
+                }
             }
 
             // add extra tab for special empty layers, if set

--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -190,6 +190,14 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
      */
     maxFeatures: 200,
 
+    /** api: config[enableTotalHits]
+     *  ``Boolean``
+     *  Set to true to run an additional WFS request to get the total number of
+     *  hits when the maxFeatures limit as been reached by a WFS GetFeature
+     *  request. Default is false.
+     */
+    enableTotalHits: false,
+
     /* i18n */
     tooltipText: "Query objects on the map",
     menuText: "Query the map",
@@ -541,9 +549,11 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
             featuresselected: function(e) {
                 this.events.fireEvent('queryresults', {
                     features: e.features,
+                    enableTotalHits: this.enableTotalHits, 
                     maxFeatures: this.maxFeatures
                 });
-                if (e.features.length == this.maxFeatures) {
+                if (this.enableTotalHits &&
+                    e.features.length == this.maxFeatures) {
                     e.object.protocol.read({
                         filter: this.filter,
                         readOptions: {output: "object"},


### PR DESCRIPTION
As for now the "max number of results is reached" message is only displayed when the current grid (=layer) actually reaches this max number, not if the limit is hit combining all the grids/layers. In that case there is no tip telling that not all results have been returned.

This PR:
- adds a parameter to enable/disable the additional Mapserver request used to get the total number of hits of the previous WFS GetFeature request
- reworks the presentation of the "maximum number of features (200)" message => the number of features available in the grid is always displayed and the warning message is moved to the left near the total number of features (displayed only if the "enableTotalHits" param is set to true).
  !

Here is an example screenshot:
[maxfeatures](https://cloud.githubusercontent.com/assets/1192331/3483173/f3476a64-038a-11e4-9e02-ab150ba24307.png)
