### PR TITLE
fix search select with IE

### DIFF
--- a/core/src/script/CGXP/widgets/FullTextSearch.js
+++ b/core/src/script/CGXP/widgets/FullTextSearch.js
@@ -249,7 +249,9 @@ cgxp.FullTextSearch = Ext.extend(Ext.Panel, {
               this.fireEvent('clear', combo);
             },
             'specialkey': function(combo, event) {
-              this.fireEvent('specialkey', combo, event);
+              if (this.position && event.getKey() == event.ENTER) {
+                this.fireEvent('specialkey', combo, event);
+              };
             },
             'render': function(component) {
                 if (this.tooltip) {


### PR DESCRIPTION
fix https://github.com/camptocamp/cgxp/issues/811
IE trigger both select and specialkey event when the user use the enter key to select one of the result, resulting in a forward of the specialkey event to the plugin side, which trigger a recentering with the last recentering position used.

so im filtering the event redirection to trigger only if a new position is set
