### PR TITLE
fix cursor in IE after dragging a ext-window

### DIFF
--- a/core/src/script/CGXP/tools/tools.js
+++ b/core/src/script/CGXP/tools/tools.js
@@ -16,6 +16,7 @@
  */
 
 /**
+ * @requires ExtOverrides/WindowDD.js
  * @include GeoExt/widgets/MapPanel.js
  */
 

--- a/ext.overrides/ExtOverrides/WindowDD.js
+++ b/ext.overrides/ExtOverrides/WindowDD.js
@@ -1,0 +1,15 @@
+/*
+    Solves a problem with Ext windows and IE, where the mouse cursor is not 
+    reinitialized after dragging the window.
+    cf: https://github.com/camptocamp/cgxp/issues/802
+    cf: http://www.sencha.com/forum/showthread.php?264999-Ext-JS-3.4.x-IE10-Move-cursor-remains-after-dragging-Window
+    HACK by http://www.sencha.com/forum/member.php?18080-Rocco
+*/
+Ext.override(Ext.Window.DD, {
+    endDrag : function(e){
+        if (Ext.isIE) {
+            Ext.defer(this.win.unghost, 1, this.win); // HACK
+        }
+        this.win.saveState();
+    }
+});


### PR DESCRIPTION
solve https://github.com/camptocamp/cgxp/issues/802
bug in Extjs 3.4.x
http://www.sencha.com/forum/showthread.php?264999-Ext-JS-3.4.x-IE10-Move-cursor-remains-after-dragging-Window
