### PR TITLE
Fix uniqueTheme example in layertree doc

### DIFF
--- a/core/src/script/CGXP/plugins/LayerTree.js
+++ b/core/src/script/CGXP/plugins/LayerTree.js
@@ -107,7 +107,6 @@ Ext.namespace("cgxp.plugins");
  *              ptype: "cgxp_layertree",
  *              id: "layertree",
  *              themes: THEMES,
- *              uniqueTheme: true,
  *              % if permalink_themes:
  *                  permalinkThemes: ${permalink_themes | n},
  *              % endif
@@ -116,6 +115,7 @@ Ext.namespace("cgxp.plugins");
  *              wmsURL: "${request.route_url('mapserverproxy', path='')}",
  *              outputTarget: "layerpanel"
  *              outputConfig: {
+ *                  uniqueTheme: true,
  *                  header: false,
  *                  flex: 1,
  *                  layout: "fit",


### PR DESCRIPTION
For branch 1.4, the code example at the beginning of the LayerTree plugin still uses "uniqueTheme" as a plugin config whereas it should be placed in the widget options.

Already OK with branch master/1.5.
