### PR TITLE
Constrain headers of editing windows

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -298,6 +298,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
             plain: true,
             resizable: false,
             disabled: true,
+            constrainHeader: true,
             items: [{
                 xtype: 'box',
                 html: this.helpText + '<hr />'
@@ -765,7 +766,8 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                 closable: false,
                 unpinnable: false,
                 draggable: true,
-                border: false
+                border: false,
+                constrainHeader: true
             }, this.attributesWindowOptions));
         }
         if (!this.attributesWindowOptions.title) {


### PR DESCRIPTION
In the editing module, the tool & editing windows are not constrained, thus the user might loose these by moving them around in the browser window and might be unable to get them back.

This PR constrains both headers of these windows so that cannot happen anymore.

Please review and merge if happy with it ;-)
