### PR TITLE
deactivate googleearth for user using IE10+

### DIFF
--- a/core/src/script/CGXP/locale/de.js
+++ b/core/src/script/CGXP/locale/de.js
@@ -257,7 +257,8 @@ GeoExt.Lang.add("de", {
 
     "cgxp.plugins.GoogleEarthView.prototype": {
         tooltipText: "In Google Earth zeigen",
-        menuText: "Google Earth"
+        menuText: "Google Earth",
+        IE10warning: "GoogleEarth ist nicht mit IE10 und neuer kompatibel"
     },
 
     "cgxp.plugins.StreetView.prototype": {

--- a/core/src/script/CGXP/locale/fr.js
+++ b/core/src/script/CGXP/locale/fr.js
@@ -262,7 +262,8 @@ GeoExt.Lang.add("fr", {
 
     "cgxp.plugins.GoogleEarthView.prototype": {
         tooltipText: "Visualiser dans GoogleEarth",
-        menuText: "GoogleEarth"
+        menuText: "GoogleEarth",
+        IE10warning: "GoogleEarth n'est pas compatible avec IE10 et plus récent"
     },
 
     "cgxp.plugins.StreetView.prototype": {

--- a/core/src/script/CGXP/plugins/GoogleEarthView.js
+++ b/core/src/script/CGXP/plugins/GoogleEarthView.js
@@ -212,6 +212,7 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
     /** i18n */
     tooltipText: "Show in GoogleEarth",
     menuText: "GoogleEarth",
+    IE10warning: "GoogleEarth is not compatible with IE10 and newer",
 
     /** private: method[init]
      */
@@ -248,8 +249,24 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
     /** private: method[activate]
      */
     activate: function() {
-        if (!this.active) {
-            this.loadingChecker();
+        if (Ext.isIE10) {
+            var win = new Ext.Window({
+                width: 400,
+                layout: 'fit',
+                cls: 'GoogleEarthIEwarning',
+                html: this.IE10warning,
+                listeners: {
+                    'close': function(p) {
+                        this.actions[0].items[0].toggle(false);
+                    },
+                    scope: this
+                }
+            });
+            win.show();
+        } else {
+            if (!this.active) {
+                this.loadingChecker();
+            }
         }
         return cgxp.plugins.GoogleEarthView.superclass.activate.call(this);
     },
@@ -257,7 +274,7 @@ cgxp.plugins.GoogleEarthView = Ext.extend(gxp.plugins.Tool, {
     /** private: method[deactivate]
      */
     deactivate: function() {
-        if (this.active) {
+        if (this.active && this.googleEarthPanel) {
             this.unloadGoogleEarth();
         }
         return cgxp.plugins.GoogleEarthView.superclass.deactivate.call(this);

--- a/core/src/theme/all.css
+++ b/core/src/theme/all.css
@@ -628,3 +628,7 @@ div.x-panel .olControlZoom a:hover {
 .x-btn-text-icon .cgxp-icon-locationchooser {
     background-image: url(img/location_chooser.png);
 }
+
+.GoogleEarthIEwarning .x-window-body {
+    padding: 10px;
+}


### PR DESCRIPTION
because GoogleEarth plugin is not natively compatible with IE10+ and we are forcing the IE compatiblity mode, making impossible to have the GoogleEarth plugin working correctly in IE10+

fix #866
