### PR TITLE
Reduce size of layergroup titles in legend panel

### DIFF
--- a/core/src/theme/all.css
+++ b/core/src/theme/all.css
@@ -332,7 +332,7 @@ div.legend img {
     display: block;
 }
 div.legend .x-form-item {
-    font-size: 1em;
+    font-size: 0.75em;
     font-weight: bold;
 }
 


### PR DESCRIPTION
... and be consistent with the size of layergroups in the layertree. As for now layergroup titles are really too big in the legend panel.
