### PR TITLE
Add missing attributes when creating a vector feature (coords recentering)

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -156,7 +156,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
             var feature = new OpenLayers.Feature.Vector(
                 new OpenLayers.Geometry.Point(this.position.lon,
                                               this.position.lat),
-                this.coordsRecenteringStyle || {}
+                {}, this.coordsRecenteringStyle || {}
             );
             this.vectorLayer.removeAllFeatures();
             this.vectorLayer.addFeatures([feature]);


### PR DESCRIPTION
OpenLayers.Feature.Vector's second argument is an attributes object, style being the third argument:
https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Feature/Vector.js#L132
