### PR TITLE
Blur FTS combo only when selecting a result, not while typing coords

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -201,6 +201,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
                 } else {
                     map.zoomToExtent(feature.bounds);
                 }
+                combo.blur();
 
                 // load related group or layer
                 if (this.layerTreeId) {

--- a/core/src/script/CGXP/widgets/FullTextSearch.js
+++ b/core/src/script/CGXP/widgets/FullTextSearch.js
@@ -234,10 +234,6 @@ cgxp.FullTextSearch = Ext.extend(Ext.Panel, {
             selectOnFocus: true
         }, this.actionConfig));
 
-        this.map.events.register('movestart', this, function(event) {
-            combo.blur();
-        });
-
         // used to close the loading panel
         this.closeLoading = new Ext.util.DelayedTask(function () {
             combo.list.hide();


### PR DESCRIPTION
As for now, the FTS combo is blurred when a map move is detected, for instance when the user has selected a result and made the map center on it.

On the other hand when typing coords in the FTS combo, we want to be able to keep typing until all the digits are provided, even if we type slowly and if the map has been recentered in the meantime.

This PR moves the blurring to the combo's "select" handler, from the mp's "movestart" one.