### PR TITLE
Add parameters to set the login buttons texts independently

### DIFF
--- a/core/src/script/CGXP/plugins/Login.js
+++ b/core/src/script/CGXP/plugins/Login.js
@@ -201,6 +201,16 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
      */
     toolbarItems: [],
 
+    /** api: config[loginToolbarText]
+     *  ``String`` Text of the login button in the toolbar. Defaults to the
+     *  value of the ``loginText`` parameter. Set to '' to display no text.
+     */
+
+    /** api: config[loginFormText]
+     *  ``String`` Text of the submit button in the login form. Defaults to the
+     *  value of the ``loginText`` parameter. Set to '' to display no text.
+     */
+
     /* i18n */
     authenticationFailureText: "Impossible to connect.",
     loggedAsText: "Logged in as ${user}",
@@ -225,7 +235,8 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
      */
     addActions: function() {
         this.submitButton = new Ext.Button({
-            text: this.loginText,
+            text: this.loginFormText !== undefined
+                ? this.loginFormText : this.loginText,
             formBind: true,
             handler: this.submitForm,
             scope: this
@@ -256,7 +267,8 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
         this.loginWindow.render(Ext.getBody());
 
         this.loginAction = new cgxp.tool.Button(Ext.apply({
-            text: this.loginText,
+            text: this.loginToolbarText !== undefined
+                ? this.loginToolbarText : this.loginText,
             tooltip: this.actionButtonTooltip,
             enableToggle: true,
             toggleGroup: this.toggleGroup,
@@ -415,7 +427,8 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
                 this.loginFormBottomCellPanel.setVisible(true);
             }
             this.actionChangePassword = false;
-            this.submitButton.setText(this.loginText);
+            this.submitButton.setText(this.loginFormText !== undefined
+                ? this.loginFormText : this.loginText);
             f.url = this.loginURL;
         }
     },


### PR DESCRIPTION
As for now, the same "loginText" parameter is used to set the text value of both the login tool (in the toolbar) and the submit button (in the login form). If one sets ``loginText: ''`` (for instance to only use an icon in the toolbar), the submit button becomes blank as well.

This PR adds 2 distinct parameters for those buttons, using "loginText" as the default value.