### PR TITLE
Add a no data value option to profile plugin

### DIFF
--- a/core/src/script/CGXP/plugins/Profile.js
+++ b/core/src/script/CGXP/plugins/Profile.js
@@ -146,6 +146,13 @@ cgxp.plugins.Profile = Ext.extend(gxp.plugins.Tool, {
      */
     nbPoints: 100,
 
+    /** api: config[noDataValue]
+     *  ``Number``
+     *  The number representing no data values in the raster layers.
+     *  Default to null.
+     */
+    noDataValue: null,
+
     /** i18n */
     tooltipText: 'Profile',
     menuText: 'Profile',
@@ -469,6 +476,10 @@ cgxp.plugins.Profile = Ext.extend(gxp.plugins.Tool, {
         Ext.each(data, function(datum) {
             var value = [parseFloat(datum.dist)];
             Ext.each(this.rasterLayers, function(layer) {
+                if (!this.noDataValue &&
+                        datum[this.valuesProperty][layer] === this.noDataValue) {
+                    datum[this.valuesProperty][layer] = NaN;
+                }
                 value.push(parseFloat(datum[this.valuesProperty][layer]));
             }, this);
             values.push(value);


### PR DESCRIPTION
This PR enables the integrator to specify a no data value.

At SITN, our raster *.bt layers have zero as no data value, thus the profiles made on them look like that:

![presse-papiers-2](https://cloud.githubusercontent.com/assets/1681332/7832469/acc4916c-045f-11e5-9524-acf14b70c808.png)

To avoid the vertical lines, we would like to specify a no data value, in order to get that kind of profile:

![presse-papiers-1](https://cloud.githubusercontent.com/assets/1681332/7832481/c42cb672-045f-11e5-9e2d-b1b1b1e1d678.png)

I hope this is the right solution...

Please review