### PR TITLE
Add option to hide print attributes in the UI

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -281,6 +281,9 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      *                          emptyText: "${_("Description")}",
      *                          autoCreate: {maxLength: 200}
      *                      }
+     *                  },
+     *                  "debug": {
+     *                      ignore: true
      *                  }
      *              }
      *          }

--- a/geoext.ux/ux/SimplePrint/lib/GeoExt.ux/SimplePrint.js
+++ b/geoext.ux/ux/SimplePrint/lib/GeoExt.ux/SimplePrint.js
@@ -160,6 +160,9 @@ GeoExt.ux.SimplePrint = Ext.extend(Ext.form.FormPanel, {
      *                      ...
      *                  }
      *              },
+     *              "debug": {
+     *                  ignore: true
+     *              },
      *              ...
      *          },
      *          ...
@@ -351,7 +354,9 @@ GeoExt.ux.SimplePrint = Ext.extend(Ext.form.FormPanel, {
         Ext.each(printProvider.getAttributes(), function(attribute) {
             templateExtraAttributes = this.fieldsExtraClientConfiguration[layout.data.name] || {};
             extraAttributes = templateExtraAttributes[attribute.name] || {};
-            this.addAttribute(attribute, extraAttributes.fieldAttributes);
+            if (!extraAttributes.ignore) {
+                this.addAttribute(attribute, extraAttributes.fieldAttributes);
+            }
         }, this);
 
         if (this.initialConfig.items) {


### PR DESCRIPTION
This PR adds the option `ignore` so that certain attributes (with a default value) are hidden in the UI.

        {
            ptype: "cgxp_print",
            ...
            options: {
                ...
                fieldsExtraClientConfiguration: {
                    "A4 portrait": {
                        ...
                        "debug": {
                        	ignore: true
                        },
                        ...
                    }
                }
            },
           ...
        },