### PR TITLE
Debug color picker without menu

### DIFF
--- a/core/src/script/CGXP/widgets/Ext.ux.ColorField.js
+++ b/core/src/script/CGXP/widgets/Ext.ux.ColorField.js
@@ -24,6 +24,11 @@ Ext.namespace('Ext.ux');
 
 Ext.ux.ColorField = Ext.extend(Ext.form.TriggerField, {
 
+    /** private: attribute[menu]
+     * ``Ext.ux.ColorMenu``
+     */
+    menu: null,
+
     invalidText: "Colors must be in a the hex format #FFFFFF.",
     regex: /^\#[0-9A-F]{6}$/i,
     allowBlank: false,


### PR DESCRIPTION
Colorpicker (used in drawing tools, fulltextsearch) can't work since the commit https://github.com/camptocamp/cgxp/commit/6a2223803b296bbe99c65d5c3a5b3045582de9c1#diff-39cfd2135c9ca93a86fa9b3f7a91362eR61

That was a board effect after correcting code for jsLint. With my change, the "color picker" works but is the code accepted by JsLint ? I'm not sur to know how to run correctly this specific test