### PR TITLE
Don't remove features when the FeaturesWindow is closed to be able to print them.

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -267,9 +267,6 @@ cgxp.plugins.FeaturesWindow = Ext.extend(cgxp.plugins.FeaturesResult, {
 
         this.events.on('queryclose', function(queryResult) {
             cgxp.tools.notification.close();
-            if (this.featuresWindow) {
-                this.featuresWindow.hide();
-            }
         }, this);
 
         map.addLayer(this.vectorLayer);


### PR DESCRIPTION
The worth case is closed when we open the print panel.

fix #904