### PR TITLE
Remove double else section

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -1675,17 +1675,6 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                 }
             }
         }
-        // Test if we try to see restricted content from an unchanged theme's groups
-        else {
-            for (var key in this.initialState) {
-                if (key.indexOf("group_layers_") === 0) {
-                    var groupName = key.substring("group_layers_".length);
-                    if (groups.indexOf(groupName) < 0) {
-                        this.restrictedContent = true;
-                    }
-                }
-            }
-        }
         Ext.each(groups.reverse(), function(t) {
             if (!this.checkGroupIsAllowed(t)) {
                 // this group is not in the list of allowed groups,


### PR DESCRIPTION
I think that this was injected with commit https://github.com/camptocamp/cgxp/commit/5599b2d7051351bb8659efb770ad185f0fe85fc0

There is now a double `else` section here: https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/widgets/tree/LayerTree.js#L1678-L1688

Please review