### PR TITLE
Set default font-size and -family for redlining labels

### DIFF
--- a/core/src/script/CGXP/widgets/RedLiningPanel.js
+++ b/core/src/script/CGXP/widgets/RedLiningPanel.js
@@ -80,6 +80,7 @@ cgxp.RedLiningPanel = Ext.extend(
                 'strokeColor': true,
                 'fontColor': true,
                 'fontSize': true,
+                'fontFamily': true,
                 'graphic': function(val) { return val == 'true'; }
             },
             line: {

--- a/sandbox/FeatureEditing/ux/widgets/FeatureEditingControler.js
+++ b/sandbox/FeatureEditing/ux/widgets/FeatureEditingControler.js
@@ -796,6 +796,8 @@ GeoExt.ux.FeatureEditingControler = Ext.extend(Ext.util.Observable, {
         feature.isLabel = true;
         var panelClass = this.featurePanelClass || GeoExt.ux.form.FeaturePanel;
         feature.style.label = feature.attributes[panelClass.prototype.labelAttribute];
+        feature.style.fontSize = '12px';
+        feature.style.fontFamily = 'sans-serif';
     },
 
     /** private: method[onCircleAdded]


### PR DESCRIPTION
Currently, when a new redlining label is added to the map, the font-size and -family is not explicitly set in the feature style (the font-size will only be set when it's changed in the edit dialog). When this feature is sent in a print request, no font-size and -family is provided, so that the default GeoTools font style will be used for the print, while on the client-side the default OpenLayers/SVG font style was used.

To avoid the discrepancy a default font-size and -family is now set when creating a label feature.

Related to https://github.com/camptocamp/baselstadt_mapbs/issues/31