### PR TITLE
fix null x/y recenter

### DIFF
--- a/core/src/script/CGXP/widgets/MapPanel.js
+++ b/core/src/script/CGXP/widgets/MapPanel.js
@@ -199,8 +199,8 @@ cgxp.MapPanel = Ext.extend(GeoExt.MapPanel, {
         this.initialState = state;
         var newCenter = this.autoProjection.tryProjection([state.x, state.y]);
         if (newCenter === null) {
-            state.x = null;
-            state.y = null;
+            delete state.x;
+            delete state.y;
         } else {
             state.x = newCenter[0];
             state.y = newCenter[1];


### PR DESCRIPTION
if x and y exist and are null, GeoExt will try to recenter on an invalid center:

x/y > center
https://github.com/geoext/geoext/blob/master/lib/GeoExt/widgets/MapPanel.js#L259
center > recenter
https://github.com/geoext/geoext/blob/master/lib/GeoExt/widgets/MapPanel.js#L361

if x/y are null, center will be created but with NaN values, and the recenter will recenter on I dont know exactly but the end result is a recenter in the middle of the maxExtent.




