### PR TITLE
Add "Copy to" functionality to Editing plugin

### DIFF
--- a/core/src/script/CGXP/locale/de.js
+++ b/core/src/script/CGXP/locale/de.js
@@ -155,6 +155,8 @@ GeoExt.Lang.add("de", {
         createBtnText: "Erstellen Sie ein neues Element",
         undoButtonText: "",
         undoButtonTooltip: "Die letzte Modifikation rückgängig machen STRG+Z",
+        copyToBtnText: "Kopieren nach",
+        copyToBtnTooltip: "Erstelle neues Feature in einem anderen Layer mit der gleichen Geometrie",
         forbiddenText: "Diese Aktion ist nicht erlaubt!",
         titleText: "Editieren",
         saveServerErrorText: "Speichern nicht möglich wegen eines Serverfehlers.",

--- a/core/src/script/CGXP/locale/fr.js
+++ b/core/src/script/CGXP/locale/fr.js
@@ -159,6 +159,8 @@ GeoExt.Lang.add("fr", {
         createBtnText: "Créer un nouvel objet",
         undoButtonText: "",
         undoButtonTooltip: "Annuler la dernière modification Ctrl+Z",
+        copyToBtnText: "Copier vers",
+        copyToBtnTooltip: "Créer un nouvel objet dans une autre couche avec la même géométrie",
         forbiddenText: "Vous n'êtes pas autorisé à réaliser cette action&nbsp;!",
         titleText: "Edition",
         saveServerErrorText: "L'enregistrement a échoué en raison d'une erreur du serveur.",

--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -423,7 +423,8 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                         layer_id: item.id, // layer_id is the id of the layer in database
                         editable: item.editable,
                         timeWidget: timeWidget,
-                        uiProvider: 'layer'
+                        uiProvider: 'layer',
+                        metadata: item.metadata
                     });
                     if (item.legendImage && styles) {
                         styles.push({


### PR DESCRIPTION
Display "Copy to" extra actions in FeatureEditorGrid depending on "copy_to" key/value pair in the layer metadata.
Note that this adds a metadata key/value pair in the layer tree node attributes.