### PR TITLE
Print autofit

### DIFF
--- a/core/examples/print.js
+++ b/core/examples/print.js
@@ -8,7 +8,7 @@ Ext.onReady(function() {
             renderTo: document.body,
             layout: "border",
             width: 1024,
-            height: 800,
+            height: 400,
             items: ["mymap", {
                 id: "left-panel",
                 region: 'west',
@@ -58,8 +58,8 @@ Ext.onReady(function() {
             units: "m",
             maxResolution: 156543.0339,
             maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            center: [0, 0],
-            zoom: 2,
+            center: [626242, 5904607],
+            zoom: 12,
             tbar: [],
             layers: [{
                 source: "osm",

--- a/geoext.ux/ux/SimplePrint/lib/GeoExt.ux/SimplePrint.js
+++ b/geoext.ux/ux/SimplePrint/lib/GeoExt.ux/SimplePrint.js
@@ -605,6 +605,7 @@ GeoExt.ux.SimplePrint = Ext.extend(Ext.form.FormPanel, {
      * Handler for the panel's expand/activate/enable event
      */
     showExtent: function() {
+        this.printPage.fit(this.mapPanel.map, {mode: "screen"});
         this.printExtent.show();
     },
 


### PR DESCRIPTION
With this pull request, the print extent auto fits the map view each time the form panel is displayed.
This is useful in case where the print panel is in an accordion layout and autoFit is set to false.
Currently the print extent fits the map view when the print panel is created. If the user navigates in the map and decides to print it, the print extent may be outside the current view extent. Instead, with this pull request, the print extent auto fits the current map view when the print form is displayed.

I also made it so the print example is zoomed to a more "real" area. It makes the print extent more significant if the map is not zoomed by the user.

Please review.

Replaces #1018.
Fixes #1017
