### PR TITLE
Force geom back from difference service to multi

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -1613,6 +1613,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
      */
     computeDifference: function(geomA, geomB, success, failure) {
         var geojson = new OpenLayers.Format.GeoJSON();
+        var multi = geomA.CLASS_NAME.indexOf('Multi') != -1;
         geomA = Ext.util.JSON.decode(geojson.write(geomA));
         geomB = Ext.util.JSON.decode(geojson.write(geomB));
 
@@ -1623,8 +1624,19 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                 geometries: [geomA, geomB]
             },
             success: function(result) {
-                success.call(this,
-                    geojson.read(result.responseText)[0].geometry);
+                var geometry = geojson.read(result.responseText)[0].geometry;
+
+                // if geomA was multi and isn't anymore force it to multi
+                if (multi) {
+                    var olgeom = OpenLayers.Geometry;
+                    if (geometry instanceof olgeom.Polygon) {
+                        geometry = new olgeom.MultiPolygon([geometry]);
+                    } else if (geometry instanceof olgeom.LineString) {
+                        geometry = new olgeom.MultiLineString([geometry]);
+                    }
+                }
+
+                success.call(this, geometry);
             },
             failure: function() {
                 failure.call(this);


### PR DESCRIPTION
With this pull request I fix an issue in editing interface where after cutting a polygon.

This issue happens when for example the layer corresponds to PostGIS table with a MultiPolygon geometry constraint. If the user tries to cut a polygon from this layer to draw a hole in the geometry, the difference service always try to return the simplest geometry as possible. Thus, PostGIS may return a polygon even if the initial geometry is a multipolygon.
When sent back to the client, it may then be impossible to save the cut geometry because of constraints.

With this pull request, the geometry is forced to multi if the original geometry was already multi which means that the constraints on the database will be satisfied.

Please review.