### PR TITLE
Prevent ghost rendering by removing/add feature on undo

### DIFF
--- a/geoext.ux/ux/FeatureEditing/lib/GeoExt.ux/FeatureEditorGrid.js
+++ b/geoext.ux/ux/FeatureEditing/lib/GeoExt.ux/FeatureEditorGrid.js
@@ -424,12 +424,15 @@ GeoExt.ux.FeatureEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
             // restore feature
             var feature = this.store.feature;
 
-            feature.geometry = Ext.apply(previous.geometry.clone(), {
-                id: feature.geometry.id
-            });
+            var layer = feature.layer;
+            // Remove feature from layer before changing its geometry
+            // then re-add it later to prevent ghost rendering
+            layer.removeFeatures([feature]);
+            feature.geometry = previous.geometry.clone();
             feature.attributes = Ext.apply({}, previous.attributes);
             feature.state = previous.state;
             this.dirty = this.isDirty();
+            layer.addFeatures([feature]);
 
             // refresh map
             var modifyControl = this.modifyControl;


### PR DESCRIPTION
One need to be careful when changing the geometry of a feature in OpenLayers because it may result in ghost geometries still being displayed on the screen. This is due to the fact that OpenLayers relies on geometries ids to check whether a DOM Element should be re-drawn or not.
Using the same id for the geometry object as @arnaud-morvan did doesn't work in case when the geometry is a multi one.
Instead it's better to remove the feature and re-add it to the layer.

Please review.