### PR TITLE
Fix GetFeature for GeoServer WFS

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -618,11 +618,13 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
             var l = self.getLayers.call(self);
             if (l.internalLayers.length > 0) {
                 protocol.format.featureType = l.internalLayers;
+                protocol.format.featureNS = cgxp.WFS_FEATURE_NS; //reset NS (updated after request)
                 this.protocol = protocol;
                 OpenLayers.Control.GetFeature.prototype.request.apply(this, arguments);
             }
             if (l.externalLayers.length > 0) {
                 externalProtocol.format.featureType = l.externalLayers;
+                protocol.format.featureNS = cgxp.WFS_FEATURE_NS; //reset NS (updated after request)
                 this.protocol = externalProtocol;
                 OpenLayers.Control.GetFeature.prototype.request.apply(this, arguments);
             }


### PR DESCRIPTION
GeoServer uses a lot the namespaces (mapped to workspaces) in WFS.
This makes sure the namespaces a reset between each query (OL discovers the
namespace and sets it in the protocol after the first query).

Something was fixed in OL as well. Hence the OL update.