### PR TITLE
Disable undo key shurtcut when disabled in Editing.

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -501,12 +501,12 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                 var handled = false;
                 switch (evt.keyCode) {
                     case 90: // z
-                        if (evt.metaKey || evt.ctrlKey) {
+                        if (editing.enableUndo && (evt.metaKey || evt.ctrlKey)) {
                             handled = draw.undo();
                         }
                         break;
                     case 89: // y
-                        if (evt.metaKey || evt.ctrlKey) {
+                        if (editing.enableUndo && (evt.metaKey || evt.ctrlKey)) {
                             handled = draw.redo();
                         }
                         break;
@@ -1014,6 +1014,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
             allowSave: true,
             allowCancel: true,
             allowDelete: true,
+            allowUndo: this.enableUndo,
             border: false,
             hideHeaders: true,
             viewConfig: {

--- a/geoext.ux/ux/FeatureEditing/lib/GeoExt.ux/FeatureEditorGrid.js
+++ b/geoext.ux/ux/FeatureEditing/lib/GeoExt.ux/FeatureEditorGrid.js
@@ -110,6 +110,12 @@ GeoExt.ux.FeatureEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
      */
     allowCancel: true,
 
+    /** api: config[allowUndo]
+     *  ``Boolean`` Set to true to allow to undo operations (CTRL-Z).
+     *  Default is true.
+     */
+    allowUndo: true,
+
     /** api: config[extraActions]
      * ``Array(Ext.menu.Item)`` List of items to put in the actions menu.
      */
@@ -354,7 +360,7 @@ GeoExt.ux.FeatureEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
             var handled = false;
             switch (evt.keyCode) {
                 case 90: // z
-                    if (evt.metaKey || evt.ctrlKey) {
+                    if (editorgrid.allowUndo && (evt.metaKey || evt.ctrlKey)) {
                         editorgrid.undo();
                         handled = true;
                     }


### PR DESCRIPTION
The previous commit was disabling the button, but missed the key
shutcuts.