### PR TITLE
Correct Content-Type when saving features

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -1094,7 +1094,8 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
     save: function(feature) {
         var protocol = new OpenLayers.Protocol.HTTP({
             url: this.layersURL + feature.attributes.__layer_id__,
-            format: new OpenLayers.Format.GeoJSON()
+            format: new OpenLayers.Format.GeoJSON(),
+            headers: {'Content-Type': 'application/json'}
         });
         var self = this;
         var validationError = null;


### PR DESCRIPTION
The Editing plugin was sending the JSON with an XML Content-Type.
Closes #1042.

I was planning to fix OpenLayers instead. Because the protocol could use the format to know what content type it should use, but the format is protocol agnostic and therefore doesn't know a thing about the Content-Type which is HTTP specific. So I've fixed it on CGXP instead.