### PR TITLE
Add maxFeatures param to query builder requests

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -445,6 +445,7 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
 
         this.protocol = new OpenLayers.Protocol.WFS({
             url: this.mapserverproxyURL,
+            maxFeatures: this.maxFeatures,
             featureType: featureType,
             featureNS: cgxp.WFS_FEATURE_NS,
             srsName: this.srsName,


### PR DESCRIPTION
Config parameters ``enable_limit_featurecollection`` and ``maxfeatures`` have been removed in GMF 1.6. See how it worked in 1.5:
https://github.com/camptocamp/c2cgeoportal/blob/1.5/c2cgeoportal/views/mapserverproxy.py#L237-L242

As a result it is no longer possible to restrict the number of features returned by a WFS request from the query builder to mapserver (even though it is still possible to set a ``MAXFEATURES`` attribute in ``LAYER``).
This PR adds ``maxFeatures`` in the WFS requests, as it is already done in the GetFeature plugin:
https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/plugins/GetFeature.js#L541