### PR TITLE
Add Ext detection for IE11 and greater. 

### DIFF
--- a/core/src/script/CGXP/widgets/WMSDatePicker.js
+++ b/core/src/script/CGXP/widgets/WMSDatePicker.js
@@ -18,6 +18,7 @@
 /**
  * @include GeoExt/data/LayerRecord.js
  * @require OpenLayers/Layer.js
+ * @require ExtOverrides/ExtendIeDetection.js
  */
 
 /** api: (define)

--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -443,6 +443,12 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     var timeWidget = item.node.timeWidget;
                     if (timeWidget) {
                         timeWidget.doLayout();
+                        if (Ext.isIE) {
+                            // redo the doLayout to force display in IE11
+                            setTimeout(function(){
+                                timeWidget.doLayout();
+                            }, 100);
+                        }
                         if (timeWidget.timeType === 'slider') {
                             var slider = timeWidget.items.get(1);
                             // compute thumb half size manually to prevent

--- a/ext.overrides/ExtOverrides/ExtendIeDetection.js
+++ b/ext.overrides/ExtOverrides/ExtendIeDetection.js
@@ -1,0 +1,33 @@
+/**
+* Get IE version from userAgent, Set Ext classes and variables if IE11 or
+* greater is detected
+*/
+var detectIE = function() {
+    if (!Ext.isIE) {
+        var ua = navigator.userAgent;
+        var re = new RegExp(".*(Trident|Edge).*rv:([0-9]{1,}[\.0-9]{0,})");
+        if (re.exec(ua) === null) {
+            return;
+        }
+        var engine = RegExp.$1;
+        var rv = parseFloat(RegExp.$2);
+        var newClasses = [];
+        Ext.isIE = true;
+        newClasses.push('ext-ie');
+        if (engine == 'Trident' && rv > 10) {
+            newClasses.push('ext-ie' + rv);
+            Ext['isIE' + rv] = true;
+        } else if (engine == 'Edge') {
+            newClasses.push('ext-ie-edge' + rv);
+            Ext['isIEEdge' + rv] = true;
+        }
+        for (var i=0, l=newClasses.length; i<l; i++) {
+            Ext.getBody().addClass(newClasses[i]);
+        }
+    }
+};
+
+/**
+* IE11 and greater are not detected anymore by ext 3.4
+*/
+detectIE();


### PR DESCRIPTION
Force WMSDatePicker layout when using IE to solve the widget not being displayed.

fix https://github.com/camptocamp/cgxp/issues/1056