### PR TITLE
Allow empty content in FTS colorpicker

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -272,6 +272,7 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
         var layer = this.vectorLayer;
         var colorpicker = new Ext.ux.ColorField({
             editable: false,
+            allowBlank: true,
             style: {
                 'background': layer.style.fillColor || '#ff0000'
             },


### PR DESCRIPTION
Reproducible in https://geomapfish-demo.camptocamp.net/1.6/
* click in the FTS colorpicker > pick a color
* the color picker border becomes red (invalid field content) and a "This field is required" tooltip appears below the standard tooltip.

See 
![39dd0cc2-a7f9-11e5-9fb1-27b48b4eba4a](https://cloud.githubusercontent.com/assets/1192331/12205925/5d4fc0b6-b63e-11e5-9d3b-256b0e05303a.png)

That's because when selecting a color, the field content is set to "":
https://github.com/camptocamp/cgxp/blob/1.6/core/src/script/CGXP/plugins/FullTextSearch.js#L281
which triggers the default blank content detection.

This PR makes sure the detection is skipped.

By the way in Firefox when clicking on the colorpicker, a text editing cursor appears in the field (not in Chrome). See:
![d7b947c8-a7fc-11e5-8188-d680e7421e1d](https://cloud.githubusercontent.com/assets/1192331/12205952/7dcf4ce4-b63e-11e5-977f-9bcb6bb14170.png)

I have not found out yet how to prevent this. Anyone has a tip?
