### PR TITLE
Edit select best feature

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -1705,19 +1705,7 @@ cgxp.plugins.Editing.GetFeature = OpenLayers.Class(OpenLayers.Control.GetFeature
             callback: function(result) {
                 if (result.success()) {
                     if (result.features.length) {
-                        if (options.single === true) {
-                            this.selectBestFeature(result.features,
-                                bounds.getCenterLonLat(), options);
-                        } else {
-                            this.select(result.features);
-                        }
-                    } else if(options.hover) {
-                        this.hoverSelect();
-                    } else {
-                        this.events.triggerEvent("clickout");
-                        if(this.clickout) {
-                            this.unselectAll();
-                        }
+                        this.select(result.features[0]);
                     }
                 }
                 else {
@@ -1729,9 +1717,6 @@ cgxp.plugins.Editing.GetFeature = OpenLayers.Class(OpenLayers.Control.GetFeature
             },
             scope: this
         });
-        if (options.hover === true) {
-            this.hoverResponse = response;
-        }
     }
 });
 

--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -1701,7 +1701,6 @@ cgxp.plugins.Editing.GetFeature = OpenLayers.Class(OpenLayers.Control.GetFeature
         OpenLayers.Element.addClass(this.map.viewPortDiv, "olCursorWait");
 
         var response = this.protocol.read({
-            maxFeatures: options.single === true ? this.maxFeatures : undefined,
             filter: filter,
             callback: function(result) {
                 if (result.success()) {


### PR DESCRIPTION
This idea behind this pull request is to avoid possible errors when selecting feature for editing purpose.

This issue was that the polygons are always taken first into account. If a point layer is on top of a polygon one, it's impossible to select the point unless the polygon layer is set to invisible.

This pull request fixes this issue by taking the first result returned by the service which takes into account the visibility order.
The pull request also removes unrequired code. The GetFeature options were not taken into account since we're in a specific case (Editing).

Demo: https://geomapfish-demo.camptocamp.net/pierre/edit