### PR TITLE
Take order of layers into account when querying server

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -546,6 +546,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
             clearTimeout(this.manageLayersTimer);
         }
         var self = this;
+        var i;
         // Add a delay to query the md.xsd because previously we query it,
         // cancel the query, query again, cancel it again,
         // and finally do the right query ...
@@ -553,8 +554,11 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
             if (this.snapControl && this.snapControl.active) {
                 this.checkSnapLayerVisibility();
             }
-            var layers = self.getEditableLayers();
-            var size = 0;
+            var editLayers = self.getEditableLayers();
+            var layerIds = [];
+            for (i = 0; i < editLayers.length; i++) {
+                layerIds.push(editLayers[i].attributes.layer_id);
+            }
             var menu = self.newFeatureBtn.menu;
             self.abortPendingRequests();
             var alreadyAvailableItems = [];
@@ -562,24 +566,15 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
                 if (!item.layerId) {
                     return;
                 }
-                // remove items that are not in the layers list anymore
-                if (!layers[item.layerId]) {
-                    menu.remove(item);
-                } else {
-                    alreadyAvailableItems.push(item.layerId);
-                }
+                menu.remove(item);
             });
-            for (var i in layers) {
-                if (layers.hasOwnProperty(i)) {
-                    size++;
-                    // only add an item for new editable layers
-                    if (alreadyAvailableItems.indexOf(parseInt(i, 10)) == -1) {
-                        self.getAttributesStore(layers[i].attributes.layer_id, null, (function(store, geometryType, layer) {
-                            menu.add(self.createMenuItem(layer, geometryType));
-                        }).createDelegate(self, [layers[i]], true));
-                    }
-                }
+            for (i = 0; i < editLayers.length; i++) {
+                var layer = editLayers[i];
+                self.getAttributesStore(layer.attributes.layer_id, null, (function(store, geometryType, layer) {
+                    menu.add(self.createMenuItem(layer, geometryType));
+                }).createDelegate(self, [layer], true));
             }
+            var size = editLayers.length;
             self.win.setVisible(!self.hideWhenNoLayer || size !== 0);
             self.win.setDisabled(size === 0);
             if (size === 0) {
@@ -763,10 +758,10 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
     getEditableLayers: function() {
         // FIXME use cache
         var tree = this.target.tools[this.layerTreeId].tree;
-        var layers = {};
+        var layers = [];
         tree.root.cascade(function(node) {
             if (node.attributes.editable && node.attributes.checked) {
-                layers[node.attributes.layer_id] = node;
+                layers.push(node);
             }
         });
         return layers;
@@ -780,10 +775,8 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
         var layerIds = [];
         var editLayers = this.getEditableLayers();
 
-        for (var i in editLayers) {
-            if (editLayers.hasOwnProperty(i)) {
-                layerIds.push(i);
-            }
+        for (var i = 0; i < editLayers.length; i++) {
+            layerIds.push(editLayers[i].attributes.layer_id);
         }
         if (layerIds.length === 0) {
             // we need to reset the cursor manually
@@ -1083,7 +1076,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
         }
         if (!this.attributesWindowOptions.title) {
             var selectedLayerId = this.editorGrid.featureInfo.attributes.__layer_id__;
-            var selectedLayerName = this.getEditableLayers()[selectedLayerId].item;
+            var selectedLayerName = this.getLayerNodeById(selectedLayerId).attributes.item;
             this.attributePopup.setTitle(OpenLayers.i18n(selectedLayerName));
         }
         this.attributePopup.add(this.editorGrid);

--- a/core/tests/spec/script/CGXP/plugins/Editing.js
+++ b/core/tests/spec/script/CGXP/plugins/Editing.js
@@ -158,11 +158,11 @@ describe('plugins.Editing', function() {
         });
         var layers;
         it('sets the editing plugin window to enabled', function() {
-            layers = {
-                'l3': {
+            layers = [
+                {
                     attributes: 'bar'
                 }
-            };
+            ];
 
             // don't use timeout to directly gets the result
             // as I see the current setTimeout function never
@@ -190,7 +190,7 @@ describe('plugins.Editing', function() {
         });
 
         it('sets the editing plugin window to disabled', function() {
-            layers = {};
+            layers = [];
             e.manageLayers();
             expect(e.win.disabled).toBeTruthy();
         });


### PR DESCRIPTION
Instead of storing the editable layers in an associative array (object) in which the keys are the layers ids, we store them in an array. The advantage is that we keep them in the order as in the tree. We can then query the server for features using the visibility order. Thus the features in the response are ordered as well.

I also simplified the way the menu is created. We may have duplicates if layers are available multiple times in the tree, but I don't think it's a big deal.

Please review.