### PR TITLE
print plugin - printExport returns an object

### DIFF
--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -630,7 +630,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                     }
 
                     var printExport = this.target.tools[this.featureProvider].printExport();
-                    if (printExport instanceof Array) {
+                    if (printExport instanceof Object) {
                         var pageCount = 1;
                         for (var dataset in printExport) {
                             if (printExport.hasOwnProperty(dataset)) {


### PR DESCRIPTION
printExport() returns an object, not an array (if used with a featureGrid... I do not know what happens with a featureWindow....).

I corrected this for version 2 (instance sitll using mpafish print 2)

Please review

