### PR TITLE
print plugin - printExport returns an object

### DIFF
--- a/core/src/script/CGXP/plugins/FeaturesWindow.js
+++ b/core/src/script/CGXP/plugins/FeaturesWindow.js
@@ -610,7 +610,7 @@ cgxp.plugins.FeaturesWindow = Ext.extend(cgxp.plugins.FeaturesResult, {
      */
     printExport: function() {
 
-        var groupedRecords = [];
+        var groupedRecords = {};
 
         if (!this.grid || !this.grid.getStore()) {
             return groupedRecords;

--- a/core/src/script/CGXP/plugins/Print.js
+++ b/core/src/script/CGXP/plugins/Print.js
@@ -630,7 +630,7 @@ cgxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                     }
 
                     var printExport = this.target.tools[this.featureProvider].printExport();
-                    if (printExport instanceof Array) {
+                    if (printExport instanceof Object) {
                         var pageCount = 1;
                         for (var dataset in printExport) {
                             if (printExport.hasOwnProperty(dataset)) {


### PR DESCRIPTION
printExport() returns an object, not an array (if used with a featureGrid... I do not know what happens with a featureWindow....).

I corrected this for version 2 (instance still using mapfish print 2)

Please review

Replaces https://github.com/camptocamp/cgxp/pull/1079
