### PR TITLE
Fix position of FTS showCenter marker

### DIFF
--- a/core/src/script/CGXP/plugins/FullTextSearch.js
+++ b/core/src/script/CGXP/plugins/FullTextSearch.js
@@ -178,8 +178,8 @@ cgxp.plugins.FullTextSearch = Ext.extend(gxp.plugins.Tool, {
         if (this.showCenter) {
             // show a point feature to materialize the center
             var feature = new OpenLayers.Feature.Vector(
-                new OpenLayers.Geometry.Point(this.position.lon,
-                                              this.position.lat),
+                new OpenLayers.Geometry.Point(this.position[0],
+                                              this.position[1]),
                 {}, this.coordsRecenteringStyle || {}
             );
             this.vectorLayer.removeAllFeatures();


### PR DESCRIPTION
The position of the crosshair displayed when feeding the fulltextsearch with coordinates  asks for ``lon``/``lat`` properties in the passed ``position``... which do not exist since ``position`` is a simple coordinates array: https://github.com/camptocamp/cgxp/blob/1.6/core/src/script/CGXP/widgets/FullTextSearch.js#L163

