### PR TITLE
Add mapPanel params to getFeatureInfo request

### DIFF
--- a/core/src/script/CGXP/plugins/GetFeature.js
+++ b/core/src/script/CGXP/plugins/GetFeature.js
@@ -477,6 +477,7 @@ cgxp.plugins.GetFeature = Ext.extend(gxp.plugins.Tool, {
                                 wmsOptions.params[param] = layer.params[param];
                             }
                         }
+                        Ext.apply(wmsOptions.params, self.target.mapPanel.params);
                         OpenLayers.Request.GET(wmsOptions);
                     }
                     return queryDone;


### PR DESCRIPTION
This was already the case for WFS GetFeature : 
https://github.com/camptocamp/cgxp/blob/3e3ccd6be240e484fb00735d9a652f06be8ef32d/core/src/script/CGXP/plugins/GetFeature.js#L552
We need this in 1.6 for parameter ``floor``.