### PR TITLE
Add a click tolerance in the editing plugin

### DIFF
--- a/core/src/script/CGXP/plugins/Editing.js
+++ b/core/src/script/CGXP/plugins/Editing.js
@@ -145,6 +145,13 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
      */
     usedMapParams: [],
 
+    /** api: config[getFeatureTolerance]
+     *  ``Integer``
+     *  Click tolerance for the filter query in pixels.
+     *  Default is 5 (as in OpenLayers).
+     */
+    getFeatureTolerance: 5,
+
     /** api: config[layersWindowOptions]
      * ``Object`` Additional options given to the layer selector window constructor.
      */
@@ -841,6 +848,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
         });
 
         var control = new cgxp.plugins.Editing.GetFeature({
+            clickTolerance: this.getFeatureTolerance,
             protocol: protocol
         });
         this.map.addControl(control);
@@ -1528,6 +1536,7 @@ cgxp.plugins.Editing = Ext.extend(gxp.plugins.Tool, {
             }
         });
         var selectControl = new cgxp.plugins.Editing.GetFeature({
+            clickTolerance: this.getFeatureTolerance,
             protocol: protocol
         });
         selectControl.events.on({


### PR DESCRIPTION
When editing a layer of points, it is not easy to select an existing one, as the used tolerance is OpenLayers default one (5 pixels).

This PR enables the integrator to specify a larger click tolerance on the map, if needed.

Please review