### PR TITLE
Add plugin profile option markerLabelSeparator

### DIFF
--- a/core/src/script/CGXP/plugins/Profile.js
+++ b/core/src/script/CGXP/plugins/Profile.js
@@ -176,6 +176,13 @@ cgxp.plugins.Profile = Ext.extend(gxp.plugins.Tool, {
         labelYOffset: 5
     }, OpenLayers.Feature.Vector.style['default']),
 
+    /** api: config[markerLabelSeparator]
+     *  ``String``
+     *  The separator to use to join distance and raster labels
+     *  (optional).
+     */
+    markerLabelSeparator: ', ',
+
     /** api: config[dygraphOptions]
      *  ``Object``
      *  Configuration object for the dygraph object created by this plugin.
@@ -572,7 +579,7 @@ cgxp.plugins.Profile = Ext.extend(gxp.plugins.Tool, {
             ]));
         }
         var style = OpenLayers.Util.extend({
-            label: label.join(', ')
+            label: label.join(this.markerLabelSeparator)
         }, this.markerStyle);
 
         this.marker = new OpenLayers.Feature.Vector(point, datum, style);


### PR DESCRIPTION
Need this to get labels on separated lines with "\n", because I have very long label with 4 rasters.