### PR TITLE
Remove notifications to mailing list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,3 @@ script:
 - env/bin/jasmine-ci --browser phantomjs
 - cd -
 - ./travis.sh
-
-notifications:
-  email:
-    recipients:
-    - c2cgeoportal@camptocamp.com


### PR DESCRIPTION
I think the default notification settings (email to committer) should be sufficient, please merge if you agree.