### PR TITLE
Only LAYERS is valid in wms spec. 

### DIFF
--- a/core/src/script/CGXP/widgets/tree/LayerTree.js
+++ b/core/src/script/CGXP/widgets/tree/LayerTree.js
@@ -1110,7 +1110,7 @@ cgxp.tree.LayerTree = Ext.extend(Ext.tree.TreePanel, {
                     child.layer = new OpenLayers.Layer.WMS(
                         child.name, child.url, {
                             STYLE: child.style,
-                            LAYER: child.name,
+                            LAYERS: child.name,
                             FORMAT: child.imageType,
                             TRANSPARENT: child.imageType == 'image/png'
                         }, {


### PR DESCRIPTION
But qgis-server accept also LAYER, and if both LAYER and LAYERS exists, data is rendered twice.

issue reported in https://jira.camptocamp.com/browse/GEO-614