### PR TITLE
Fix 'like' filters with special characteres

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -275,6 +275,11 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                 return false;
             } else if (f.CLASS_NAME == "OpenLayers.Filter.Comparison") {
                 f.matchCase = this.matchCase;
+                // On 'Like' comparison, analyse a string 'as is', not as regexp.
+                if (f.type === OpenLayers.Filter.Comparison.LIKE) {
+                    var toEscape = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g;
+                    f.value = f.value.replace(toEscape, "\\$&");
+                }
             }
         }
         return true;


### PR DESCRIPTION
I merge that into 1.6 or into master ?

Fix: #1124

**tmp** demo: https://testgmf.sig.cloud.camptocamp.net/bge/theme/Transport