### PR TITLE
Escape double quotes in query builder

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -265,6 +265,8 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
         var filters = filter.filters || [filter];
         for (var i=0, l=filters.length; i<l; i++) {
             var f = filters[i];
+            // Escape double quote on all operations.
+            f.value = f.value.replace(/["]/g, "\\$&");
             if (f.CLASS_NAME == 'OpenLayers.Filter.Logical') {
                 if (!this.checkFilter(f)) {
                     return false;


### PR DESCRIPTION
Fix: #1126
Fix also: GEO-619

Now we are able to query something like `Malval "test"`. 