### PR TITLE
Only escape quote in query when doing a textual query

### DIFF
--- a/core/src/script/CGXP/plugins/QueryBuilder.js
+++ b/core/src/script/CGXP/plugins/QueryBuilder.js
@@ -265,8 +265,6 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
         var filters = filter.filters || [filter];
         for (var i=0, l=filters.length; i<l; i++) {
             var f = filters[i];
-            // Escape double quote on all operations.
-            f.value = f.value.replace(/["]/g, "\\$&");
             if (f.CLASS_NAME == 'OpenLayers.Filter.Logical') {
                 if (!this.checkFilter(f)) {
                     return false;
@@ -276,6 +274,8 @@ cgxp.plugins.QueryBuilder = Ext.extend(gxp.plugins.Tool, {
                 alert(this.incompleteFormText);
                 return false;
             } else if (f.CLASS_NAME == "OpenLayers.Filter.Comparison") {
+                // Escape double quote on all operations.
+                f.value = f.value.replace(/["]/g, "\\$&");
                 f.matchCase = this.matchCase;
                 // On 'Like' comparison, analyse a string 'as is', not as regexp.
                 if (f.type === OpenLayers.Filter.Comparison.LIKE) {


### PR DESCRIPTION
fix https://jira.camptocamp.com/browse/GEO-696

Spatial filters (OpenLayers.Filter.Spatial) value is of type OpenLayers_Geometry, so one cant do a string replacement on it and it's not useful anyway. Same for boolean filters.
Only textual filters (OpenLayers.Filter.Comparison) are concerned by this quote escaping.