### PR TITLE
Fix syntax used to read a JSON response

### DIFF
--- a/core/src/script/CGXP/plugins/Login.js
+++ b/core/src/script/CGXP/plugins/Login.js
@@ -620,7 +620,7 @@ cgxp.plugins.Login = Ext.extend(gxp.plugins.Tool, {
                 if (this.actionChangePassword) {
                     this.submitButton.setIconClass('');
                     this.loginWindow.hide();
-                    var response = new OpenLayers.format.json.read(evt.response.responseText);
+                    var response = new OpenLayers.Format.JSON().read(evt.response.responseText);
                     if (response.success) {
                         Ext.Msg.alert(this.pwdChangeOkTitle, this.pwdChangeOkText);
                     }


### PR DESCRIPTION
The current syntax used in the Login plugin to read the response from the server after changing a password causes a JS error:
```
Login.js:601 Uncaught TypeError: Cannot read property 'json' of undefined
```
preventing the confirmation message from being displayed.

The PR fixes the error, by the way using a syntax already used at https://github.com/camptocamp/cgxp/blob/master/core/src/script/CGXP/plugins/Profile.js#L377

Question: do we need to add
```
@include OpenLayers/Format/JSON.js
```
at the top of the Login plugin? There is no such include in the Profile plugin.