### PR TITLE
Use jstool 0.6 in cgxp

### DIFF
--- a/core/src/doc/requirements
+++ b/core/src/doc/requirements
@@ -1,5 +1,5 @@
 Jinja2
-JSTools
+JSTools==0.6
 Sphinx
 alabaster
 requests[security]


### PR DESCRIPTION
Fix: https://jira.camptocamp.com/browse/GEO-1120 (doc 1.6 is not available)

Because jstools  has change to use python3
Must be ported to master too !